### PR TITLE
repo: add CentOS Stream 8

### DIFF
--- a/repo/cs8-aarch64-appstream.json
+++ b/repo/cs8-aarch64-appstream.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://msync.centos.org/centos/8-stream/AppStream/aarch64/os/",
+        "platform-id": "el8",
+        "snapshot-id": "cs8-aarch64-appstream",
+        "storage": "public"
+}

--- a/repo/cs8-aarch64-baseos.json
+++ b/repo/cs8-aarch64-baseos.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://msync.centos.org/centos/8-stream/BaseOS/aarch64/os/",
+        "platform-id": "el8",
+        "snapshot-id": "cs8-aarch64-baseos",
+        "storage": "public"
+}

--- a/repo/cs8-ppc64le-appstream.json
+++ b/repo/cs8-ppc64le-appstream.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://msync.centos.org/centos/8-stream/AppStream/ppc64le/os/",
+        "platform-id": "el8",
+        "snapshot-id": "cs8-ppc64le-appstream",
+        "storage": "public"
+}

--- a/repo/cs8-ppc64le-baseos.json
+++ b/repo/cs8-ppc64le-baseos.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://msync.centos.org/centos/8-stream/BaseOS/ppc64le/os/",
+        "platform-id": "el8",
+        "snapshot-id": "cs8-ppc64le-baseos",
+        "storage": "public"
+}

--- a/repo/cs8-x86_64-appstream.json
+++ b/repo/cs8-x86_64-appstream.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://msync.centos.org/centos/8-stream/AppStream/x86_64/os/",
+        "platform-id": "el8",
+        "snapshot-id": "cs8-x86_64-appstream",
+        "storage": "public"
+}

--- a/repo/cs8-x86_64-baseos.json
+++ b/repo/cs8-x86_64-baseos.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://msync.centos.org/centos/8-stream/BaseOS/x86_64/os/",
+        "platform-id": "el8",
+        "snapshot-id": "cs8-x86_64-baseos",
+        "storage": "public"
+}


### PR DESCRIPTION
Add repositories for CentOS Stream 8. All architectures are included (note
that s390x isn't supported by Stream 8). BaseOS and AppStream should be fine
for our needs, we might need to add RT/PowerTools later.

I chose msync.centos.org as the source, this is what the docs recommends:
https://wiki.centos.org/HowTos/CreatePublicMirrors