### PR TITLE
repo: Add Google Cloud Platform el8 repositories

### DIFF
--- a/repo/el8-x86_64-google-cloud-sdk.json
+++ b/repo/el8-x86_64-google-cloud-sdk.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64",
+        "platform-id": "el8",
+        "snapshot-id": "el8-x86_64-google-cloud-sdk",
+        "storage": "public"
+}

--- a/repo/el8-x86_64-google-compute-engine.json
+++ b/repo/el8-x86_64-google-compute-engine.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable",
+        "platform-id": "el8",
+        "snapshot-id": "el8-x86_64-google-compute-engine",
+        "storage": "public"
+}


### PR DESCRIPTION
Add repositories for RHEL-8 x86_64 with Google Cloud Platform Guest
tools and their SDK. GCP supports only x86_64.

This is needed to generate image test cases for the new `gce-byos` image - https://github.com/osbuild/osbuild-composer/pull/1365

Signed-off-by: Tomas Hozza <thozza@redhat.com>