### PR TITLE
Add repository definitions needed for RHEL ec2 images

### DIFF
--- a/repo/el8-aarch64-rhui-3.json
+++ b/repo/el8-aarch64-rhui-3.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rel-eng/rhel-8/RHUI/latest-RHUI-Client-3-RHEL-8/compose/RHUI/aarch64/os/",
+        "platform-id": "el8",
+        "snapshot-id": "el8-aarch64-rhui-n8.5",
+        "storage": "rhvpn"
+}

--- a/repo/el8-x86_64-ha-n8.5.json
+++ b/repo/el8-x86_64-ha-n8.5.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5.0/compose/HighAvailability/x86_64/os/",
+        "platform-id": "el8",
+        "snapshot-id": "el8-x86_64-rt-n8.5",
+        "storage": "rhvpn"
+}

--- a/repo/el8-x86_64-rhui-3.json
+++ b/repo/el8-x86_64-rhui-3.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rel-eng/rhel-8/RHUI/latest-RHUI-Client-3-RHEL-8/compose/RHUI/x86_64/os/",
+        "platform-id": "el8",
+        "snapshot-id": "el8-x86_64-rhui-3",
+        "storage": "rhvpn"
+}


### PR DESCRIPTION
Mirror RHUI client repo for RHEL-8 and x86_64 and aarch64.
Mirror HA repo for RHEL-8.5 and x86_64.

This is required for generating image test cases in https://github.com/osbuild/osbuild-composer/pull/1607