### PR TITLE
Fix copy&paste error from PR#11

### DIFF
--- a/repo/el8-aarch64-rhui-3.json
+++ b/repo/el8-aarch64-rhui-3.json
@@ -1,6 +1,6 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rel-eng/rhel-8/RHUI/latest-RHUI-Client-3-RHEL-8/compose/RHUI/aarch64/os/",
         "platform-id": "el8",
-        "snapshot-id": "el8-aarch64-rhui-n8.5",
+        "snapshot-id": "el8-aarch64-rhui-3",
         "storage": "rhvpn"
 }

--- a/repo/el8-x86_64-ha-n8.5.json
+++ b/repo/el8-x86_64-ha-n8.5.json
@@ -1,6 +1,6 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5.0/compose/HighAvailability/x86_64/os/",
         "platform-id": "el8",
-        "snapshot-id": "el8-x86_64-rt-n8.5",
+        "snapshot-id": "el8-x86_64-ha-n8.5",
         "storage": "rhvpn"
 }


### PR DESCRIPTION
`el8-x86_64-ha-n8.5` repository was mistakenly named as
`el8-x86_64-rt-n8.5`.

`el8-aarch64-rhui-3` repository was mistakenly named as
`el8-aarch64-rhui-n8.5`.

Related to #11 

Signed-off-by: Tomas Hozza <thozza@redhat.com>