### PR TITLE
Add 8.6 and 9.0 repos for SAP images and RHEL-9.0 GA repos

### DIFF
--- a/repo/el8-x86_64-ansible-2.json
+++ b/repo/el8-x86_64-ansible-2.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://rhsm-pulp.corp.redhat.com/content/dist/layered/rhel8/x86_64/ansible/2/os/",
+        "platform-id": "el8",
+        "snapshot-id": "el8-x86_64-ansible-2",
+        "storage": "rhvpn"
+}

--- a/repo/el8-x86_64-sap-n8.6.json
+++ b/repo/el8-x86_64-sap-n8.6.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.6/compose/SAP/x86_64/os/",
+        "platform-id": "el8",
+        "snapshot-id": "el8-x86_64-sap-n8.6",
+        "storage": "rhvpn"
+}

--- a/repo/el8-x86_64-saphana-n8.6.json
+++ b/repo/el8-x86_64-saphana-n8.6.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.6/compose/SAPHANA/x86_64/os/",
+        "platform-id": "el8",
+        "snapshot-id": "el8-x86_64-saphana-n8.6",
+        "storage": "rhvpn"
+}

--- a/repo/el9-aarch64-appstream-n9.0-beta.json
+++ b/repo/el9-aarch64-appstream-n9.0-beta.json
@@ -1,6 +1,6 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0/compose/AppStream/aarch64/os/",
         "platform-id": "el9",
-        "snapshot-id": "el9-aarch64-appstream-n9.0",
+        "snapshot-id": "el9-aarch64-appstream-n9.0-beta",
         "storage": "rhvpn"
 }

--- a/repo/el9-aarch64-appstream-n9.0.json
+++ b/repo/el9-aarch64-appstream-n9.0.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/AppStream/aarch64/os/",
+        "platform-id": "el9",
+        "snapshot-id": "el9-aarch64-appstream-n9.0",
+        "storage": "rhvpn"
+}

--- a/repo/el9-aarch64-baseos-n9.0-beta.json
+++ b/repo/el9-aarch64-baseos-n9.0-beta.json
@@ -1,6 +1,6 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0/compose/BaseOS/aarch64/os/",
         "platform-id": "el9",
-        "snapshot-id": "el9-aarch64-baseos-n9.0",
+        "snapshot-id": "el9-aarch64-baseos-n9.0-beta",
         "storage": "rhvpn"
 }

--- a/repo/el9-aarch64-baseos-n9.0.json
+++ b/repo/el9-aarch64-baseos-n9.0.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/BaseOS/aarch64/os/",
+        "platform-id": "el9",
+        "snapshot-id": "el9-aarch64-baseos-n9.0",
+        "storage": "rhvpn"
+}

--- a/repo/el9-ppc64le-appstream-n9.0-beta.json
+++ b/repo/el9-ppc64le-appstream-n9.0-beta.json
@@ -1,6 +1,6 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0/compose/AppStream/ppc64le/os/",
         "platform-id": "el9",
-        "snapshot-id": "el9-ppc64le-appstream-n9.0",
+        "snapshot-id": "el9-ppc64le-appstream-n9.0-beta",
         "storage": "rhvpn"
 }

--- a/repo/el9-ppc64le-appstream-n9.0.json
+++ b/repo/el9-ppc64le-appstream-n9.0.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/AppStream/ppc64le/os/",
+        "platform-id": "el9",
+        "snapshot-id": "el9-ppc64le-appstream-n9.0",
+        "storage": "rhvpn"
+}

--- a/repo/el9-ppc64le-baseos-n9.0-beta.json
+++ b/repo/el9-ppc64le-baseos-n9.0-beta.json
@@ -1,6 +1,6 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0/compose/BaseOS/ppc64le/os/",
         "platform-id": "el9",
-        "snapshot-id": "el9-ppc64le-baseos-n9.0",
+        "snapshot-id": "el9-ppc64le-baseos-n9.0-beta",
         "storage": "rhvpn"
 }

--- a/repo/el9-ppc64le-baseos-n9.0.json
+++ b/repo/el9-ppc64le-baseos-n9.0.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/BaseOS/ppc64le/os/",
+        "platform-id": "el9",
+        "snapshot-id": "el9-ppc64le-baseos-n9.0",
+        "storage": "rhvpn"
+}

--- a/repo/el9-s390x-appstream-n9.0-beta.json
+++ b/repo/el9-s390x-appstream-n9.0-beta.json
@@ -1,6 +1,6 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0/compose/AppStream/s390x/os/",
         "platform-id": "el9",
-        "snapshot-id": "el9-s390x-appstream-n9.0",
+        "snapshot-id": "el9-s390x-appstream-n9.0-beta",
         "storage": "rhvpn"
 }

--- a/repo/el9-s390x-appstream-n9.0.json
+++ b/repo/el9-s390x-appstream-n9.0.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/AppStream/s390x/os/",
+        "platform-id": "el9",
+        "snapshot-id": "el9-s390x-appstream-n9.0",
+        "storage": "rhvpn"
+}

--- a/repo/el9-s390x-baseos-n9.0-beta.json
+++ b/repo/el9-s390x-baseos-n9.0-beta.json
@@ -1,6 +1,6 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0/compose/BaseOS/s390x/os/",
         "platform-id": "el9",
-        "snapshot-id": "el9-s390x-baseos-n9.0",
+        "snapshot-id": "el9-s390x-baseos-n9.0-beta",
         "storage": "rhvpn"
 }

--- a/repo/el9-s390x-baseos-n9.0.json
+++ b/repo/el9-s390x-baseos-n9.0.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/BaseOS/s390x/os/",
+        "platform-id": "el9",
+        "snapshot-id": "el9-s390x-baseos-n9.0",
+        "storage": "rhvpn"
+}

--- a/repo/el9-x86_64-appstream-n9.0-beta.json
+++ b/repo/el9-x86_64-appstream-n9.0-beta.json
@@ -1,6 +1,6 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0/compose/AppStream/x86_64/os/",
         "platform-id": "el9",
-        "snapshot-id": "el9-x86_64-appstream-n9.0",
+        "snapshot-id": "el9-x86_64-appstream-n9.0-beta",
         "storage": "rhvpn"
 }

--- a/repo/el9-x86_64-appstream-n9.0.json
+++ b/repo/el9-x86_64-appstream-n9.0.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/AppStream/x86_64/os/",
+        "platform-id": "el9",
+        "snapshot-id": "el9-x86_64-appstream-n9.0",
+        "storage": "rhvpn"
+}

--- a/repo/el9-x86_64-baseos-n9.0-beta.json
+++ b/repo/el9-x86_64-baseos-n9.0-beta.json
@@ -1,6 +1,6 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0/compose/BaseOS/x86_64/os/",
         "platform-id": "el9",
-        "snapshot-id": "el9-x86_64-baseos-n9.0",
+        "snapshot-id": "el9-x86_64-baseos-n9.0-beta",
         "storage": "rhvpn"
 }

--- a/repo/el9-x86_64-baseos-n9.0.json
+++ b/repo/el9-x86_64-baseos-n9.0.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/BaseOS/x86_64/os/",
+        "platform-id": "el9",
+        "snapshot-id": "el9-x86_64-baseos-n9.0",
+        "storage": "rhvpn"
+}

--- a/repo/el9-x86_64-ha-n9.0.json
+++ b/repo/el9-x86_64-ha-n9.0.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/HighAvailability/x86_64/os/",
+        "platform-id": "el9",
+        "snapshot-id": "el9-x86_64-ha-n9.0",
+        "storage": "rhvpn"
+}

--- a/repo/el9-x86_64-rt-n9.0-beta.json
+++ b/repo/el9-x86_64-rt-n9.0-beta.json
@@ -1,6 +1,6 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9-Beta/latest-RHEL-9.0/compose/RT/x86_64/os/",
         "platform-id": "el9",
-        "snapshot-id": "el9-x86_64-rt-n9.0",
+        "snapshot-id": "el9-x86_64-rt-n9.0-beta",
         "storage": "rhvpn"
 }

--- a/repo/el9-x86_64-rt-n9.0.json
+++ b/repo/el9-x86_64-rt-n9.0.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/RT/x86_64/os/",
+        "platform-id": "el9",
+        "snapshot-id": "el9-x86_64-rt-n9.0",
+        "storage": "rhvpn"
+}

--- a/repo/el9-x86_64-sap-n9.0.json
+++ b/repo/el9-x86_64-sap-n9.0.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/SAP/x86_64/os/",
+        "platform-id": "el9",
+        "snapshot-id": "el9-x86_64-sap-n9.0",
+        "storage": "rhvpn"
+}

--- a/repo/el9-x86_64-saphana-n9.0.json
+++ b/repo/el9-x86_64-saphana-n9.0.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-9/nightly/RHEL-9/latest-RHEL-9.0/compose/SAPHANA/x86_64/os/",
+        "platform-id": "el9",
+        "snapshot-id": "el9-x86_64-saphana-n9.0",
+        "storage": "rhvpn"
+}


### PR DESCRIPTION
- Add RHEL-8.6 repos required by EC2 SAP images
- Rename existing RHEL-9.0 snapshots to RHEL-9.0-Beta
- Add repo definitions for RHEL-9.0 GA snapshots
- Add RHEL-9.0 repos required by EC2 HA and SAP images