### PR TITLE
Move from nightly to released repos for RHEL-8.5

### DIFF
--- a/repo/el8-aarch64-appstream-n8.5.json
+++ b/repo/el8-aarch64-appstream-n8.5.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "http://download.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5/compose/AppStream/aarch64/os/",
-        "platform-id": "el8",
-        "snapshot-id": "el8-aarch64-appstream-n8.5",
-        "storage": "rhvpn"
-}

--- a/repo/el8-aarch64-appstream-r8.5.json
+++ b/repo/el8-aarch64-appstream-r8.5.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5/compose/AppStream/aarch64/os/",
+        "platform-id": "el8",
+        "snapshot-id": "el8-aarch64-appstream-r8.5",
+        "storage": "rhvpn"
+}

--- a/repo/el8-aarch64-baseos-n8.5.json
+++ b/repo/el8-aarch64-baseos-n8.5.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "http://download.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5/compose/BaseOS/aarch64/os/",
-        "platform-id": "el8",
-        "snapshot-id": "el8-aarch64-baseos-n8.5",
-        "storage": "rhvpn"
-}

--- a/repo/el8-aarch64-baseos-r8.5.json
+++ b/repo/el8-aarch64-baseos-r8.5.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5/compose/BaseOS/aarch64/os/",
+        "platform-id": "el8",
+        "snapshot-id": "el8-aarch64-baseos-r8.5",
+        "storage": "rhvpn"
+}

--- a/repo/el8-ppc64le-appstream-n8.5.json
+++ b/repo/el8-ppc64le-appstream-n8.5.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "http://download.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5/compose/AppStream/ppc64le/os/",
-        "platform-id": "el8",
-        "snapshot-id": "el8-ppc64le-appstream-n8.5",
-        "storage": "rhvpn"
-}

--- a/repo/el8-ppc64le-appstream-r8.5.json
+++ b/repo/el8-ppc64le-appstream-r8.5.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5/compose/AppStream/ppc64le/os/",
+        "platform-id": "el8",
+        "snapshot-id": "el8-ppc64le-appstream-r8.5",
+        "storage": "rhvpn"
+}

--- a/repo/el8-ppc64le-baseos-n8.5.json
+++ b/repo/el8-ppc64le-baseos-n8.5.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "http://download.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5/compose/BaseOS/ppc64le/os/",
-        "platform-id": "el8",
-        "snapshot-id": "el8-ppc64le-baseos-n8.5",
-        "storage": "rhvpn"
-}

--- a/repo/el8-ppc64le-baseos-r8.5.json
+++ b/repo/el8-ppc64le-baseos-r8.5.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5/compose/BaseOS/ppc64le/os/",
+        "platform-id": "el8",
+        "snapshot-id": "el8-ppc64le-baseos-r8.5",
+        "storage": "rhvpn"
+}

--- a/repo/el8-s390x-appstream-n8.5.json
+++ b/repo/el8-s390x-appstream-n8.5.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "http://download.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5/compose/AppStream/s390x/os/",
-        "platform-id": "el8",
-        "snapshot-id": "el8-s390x-appstream-n8.5",
-        "storage": "rhvpn"
-}

--- a/repo/el8-s390x-appstream-r8.5.json
+++ b/repo/el8-s390x-appstream-r8.5.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5/compose/AppStream/s390x/os/",
+        "platform-id": "el8",
+        "snapshot-id": "el8-s390x-appstream-r8.5",
+        "storage": "rhvpn"
+}

--- a/repo/el8-s390x-baseos-n8.5.json
+++ b/repo/el8-s390x-baseos-n8.5.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "http://download.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5/compose/BaseOS/s390x/os/",
-        "platform-id": "el8",
-        "snapshot-id": "el8-s390x-baseos-n8.5",
-        "storage": "rhvpn"
-}

--- a/repo/el8-s390x-baseos-r8.5.json
+++ b/repo/el8-s390x-baseos-r8.5.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5/compose/BaseOS/s390x/os/",
+        "platform-id": "el8",
+        "snapshot-id": "el8-s390x-baseos-r8.5",
+        "storage": "rhvpn"
+}

--- a/repo/el8-x86_64-appstream-n8.5.json
+++ b/repo/el8-x86_64-appstream-n8.5.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "http://download.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5/compose/AppStream/x86_64/os/",
-        "platform-id": "el8",
-        "snapshot-id": "el8-x86_64-appstream-n8.5",
-        "storage": "rhvpn"
-}

--- a/repo/el8-x86_64-appstream-r8.5.json
+++ b/repo/el8-x86_64-appstream-r8.5.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5/compose/AppStream/x86_64/os/",
+        "platform-id": "el8",
+        "snapshot-id": "el8-x86_64-appstream-r8.5",
+        "storage": "rhvpn"
+}

--- a/repo/el8-x86_64-baseos-n8.5.json
+++ b/repo/el8-x86_64-baseos-n8.5.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "http://download.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5/compose/BaseOS/x86_64/os/",
-        "platform-id": "el8",
-        "snapshot-id": "el8-x86_64-baseos-n8.5",
-        "storage": "rhvpn"
-}

--- a/repo/el8-x86_64-baseos-r8.5.json
+++ b/repo/el8-x86_64-baseos-r8.5.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5/compose/BaseOS/x86_64/os/",
+        "platform-id": "el8",
+        "snapshot-id": "el8-x86_64-baseos-r8.5",
+        "storage": "rhvpn"
+}

--- a/repo/el8-x86_64-ha-n8.5.json
+++ b/repo/el8-x86_64-ha-n8.5.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "http://download.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5.0/compose/HighAvailability/x86_64/os/",
-        "platform-id": "el8",
-        "snapshot-id": "el8-x86_64-ha-n8.5",
-        "storage": "rhvpn"
-}

--- a/repo/el8-x86_64-ha-r8.5.json
+++ b/repo/el8-x86_64-ha-r8.5.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5.0/compose/HighAvailability/x86_64/os/",
+        "platform-id": "el8",
+        "snapshot-id": "el8-x86_64-ha-r8.5",
+        "storage": "rhvpn"
+}

--- a/repo/el8-x86_64-rt-n8.5.json
+++ b/repo/el8-x86_64-rt-n8.5.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "http://download.eng.bos.redhat.com/rhel-8/nightly/RHEL-8/latest-RHEL-8.5/compose/RT/x86_64/os/",
-        "platform-id": "el8",
-        "snapshot-id": "el8-x86_64-rt-n8.5",
-        "storage": "rhvpn"
-}

--- a/repo/el8-x86_64-rt-r8.5.json
+++ b/repo/el8-x86_64-rt-r8.5.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5/compose/RT/x86_64/os/",
+        "platform-id": "el8",
+        "snapshot-id": "el8-x86_64-rt-r8.5",
+        "storage": "rhvpn"
+}


### PR DESCRIPTION
The previously used URLs for nightly RHEL-8.5 repositories don't exist
any more.

Signed-off-by: Tomas Hozza <thozza@redhat.com>