### PR TITLE
repo: fix platform-id and snapshot-id for cs9-ppc64le-appstream

### DIFF
--- a/repo/cs9-ppc64le-appstream.json
+++ b/repo/cs9-ppc64le-appstream.json
@@ -1,6 +1,6 @@
 {
         "base-url": "https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/AppStream/ppc64le/os/",
-        "platform-id": "el8",
-        "snapshot-id": "cs8-ppc64le-appstream",
+        "platform-id": "el9",
+        "snapshot-id": "cs9-ppc64le-appstream",
         "storage": "public"
 }


### PR DESCRIPTION
This one particular file was accidentally created with el8/cs8 IDs