### PR TITLE
repo/cs9: switch to development repositories

### DIFF
--- a/repo/cs9-aarch64-appstream.json
+++ b/repo/cs9-aarch64-appstream.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/AppStream/aarch64/os/",
+        "base-url": "https://composes.stream.centos.org/development/latest-CentOS-Stream/compose/AppStream/aarch64/os/",
         "platform-id": "el9",
         "snapshot-id": "cs9-aarch64-appstream",
         "storage": "public"

--- a/repo/cs9-aarch64-baseos.json
+++ b/repo/cs9-aarch64-baseos.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/BaseOS/aarch64/os/",
+        "base-url": "https://composes.stream.centos.org/development/latest-CentOS-Stream/compose/BaseOS/aarch64/os/",
         "platform-id": "el9",
         "snapshot-id": "cs9-aarch64-baseos",
         "storage": "public"

--- a/repo/cs9-ppc64le-appstream.json
+++ b/repo/cs9-ppc64le-appstream.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/AppStream/ppc64le/os/",
+        "base-url": "https://composes.stream.centos.org/development/latest-CentOS-Stream/compose/AppStream/ppc64le/os/",
         "platform-id": "el9",
         "snapshot-id": "cs9-ppc64le-appstream",
         "storage": "public"

--- a/repo/cs9-ppc64le-baseos.json
+++ b/repo/cs9-ppc64le-baseos.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/BaseOS/ppc64le/os/",
+        "base-url": "https://composes.stream.centos.org/development/latest-CentOS-Stream/compose/BaseOS/ppc64le/os/",
         "platform-id": "el9",
         "snapshot-id": "cs9-ppc64le-baseos",
         "storage": "public"

--- a/repo/cs9-s390x-appstream.json
+++ b/repo/cs9-s390x-appstream.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/AppStream/s390x/os/",
+        "base-url": "https://composes.stream.centos.org/development/latest-CentOS-Stream/compose/AppStream/s390x/os/",
         "platform-id": "el9",
         "snapshot-id": "cs9-s390x-appstream",
         "storage": "public"

--- a/repo/cs9-s390x-baseos.json
+++ b/repo/cs9-s390x-baseos.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/BaseOS/s390x/os/",
+        "base-url": "https://composes.stream.centos.org/development/latest-CentOS-Stream/compose/BaseOS/s390x/os/",
         "platform-id": "el9",
         "snapshot-id": "cs9-s390x-baseos",
         "storage": "public"

--- a/repo/cs9-x86_64-appstream.json
+++ b/repo/cs9-x86_64-appstream.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/AppStream/x86_64/os/",
+        "base-url": "https://composes.stream.centos.org/development/latest-CentOS-Stream/compose/AppStream/x86_64/os/",
         "platform-id": "el9",
         "snapshot-id": "cs9-x86_64-appstream",
         "storage": "public"

--- a/repo/cs9-x86_64-baseos.json
+++ b/repo/cs9-x86_64-baseos.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/BaseOS/x86_64/os/",
+        "base-url": "https://composes.stream.centos.org/development/latest-CentOS-Stream/compose/BaseOS/x86_64/os/",
         "platform-id": "el9",
         "snapshot-id": "cs9-x86_64-baseos",
         "storage": "public"

--- a/repo/cs9-x86_64-rt.json
+++ b/repo/cs9-x86_64-rt.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "https://composes.stream.centos.org/production/latest-CentOS-Stream/compose/RT/x86_64/os/",
+        "base-url": "https://composes.stream.centos.org/development/latest-CentOS-Stream/compose/RT/x86_64/os/",
         "platform-id": "el9",
         "snapshot-id": "cs9-x86_64-rt",
         "storage": "public"


### PR DESCRIPTION
We need more up-to-date packages than what's available in the production
repositories for CS9.  Since it hasn't been released yet, a lot of
packages are still building support for the distro and getting released
frequently, so testing against "production" can cause issues.

Currently, we need the latest osinfo-db for testing in CI and, although
it was released 3 weeks ago and was made available immediately in the
development repos, it is still not available in production.