### PR TITLE
repo: fix 7.9 dotnet URL

### DIFF
--- a/repo/el7-x86_64-server-dotnet-r1.1.json
+++ b/repo/el7-x86_64-server-dotnet-r1.1.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download.eng.bos.redhat.com/rhel-7/rel-eng/dotNET-1.1-RHEL-7-20161128.0/compose/Server/x86_64/",
+        "base-url": "http://download.eng.bos.redhat.com/rhel-7/rel-eng/dotNET-1.1-RHEL-7-20161128.0/compose/Server/x86_64/os/",
         "platform-id": "el7",
         "snapshot-id": "el7-x86_64-server-dotnet-r1.1",
         "storage": "rhvpn"


### PR DESCRIPTION
Need to point to the folder with the repodata.