### PR TITLE
repo: fix 7.9 server-rt url

### DIFF
--- a/repo/el7-x86_64-server-rt-r7.9.json
+++ b/repo/el7-x86_64-server-rt-r7.9.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "hhttp://download.eng.bos.redhat.com/rhel-7/rel-eng/RHEL-7/latest-RHEL-7.9/compose/Server-RT/x86_64/os/",
+        "base-url": "http://download.eng.bos.redhat.com/rhel-7/rel-eng/RHEL-7/latest-RHEL-7.9/compose/Server-RT/x86_64/os/",
         "platform-id": "el7",
         "snapshot-id": "el7-x86_64-server-rt-r7.9",
         "storage": "rhvpn"


### PR DESCRIPTION
It is "http" not "hhttp".