### PR TITLE
repo: add azure rhui for el8 definitions

### DIFF
--- a/repo/el8-x86_64-rhui-azure.json
+++ b/repo/el8-x86_64-rhui-azure.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://download-node-02.eng.bos.redhat.com/devel/stratosphere/azure/RHEL-offers/RHEL-8/RHEL-8.6/",
+        "platform-id": "el8",
+        "snapshot-id": "el8-x86_64-rhui-azure",
+        "storage": "rhvpn"
+}


### PR DESCRIPTION
This adds syncing of the RHUI client for RHEL 8. The current devel folder structure has 8.5 and 8.6 but they are exactly the same and the repo definition suggests the same is used for all non EUS release. So just have one rpmrepo for all of el8.