### PR TITLE
repo: use plain http for el8-x86_64-rhui-azure

### DIFF
--- a/repo/el8-x86_64-rhui-azure.json
+++ b/repo/el8-x86_64-rhui-azure.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "https://download-node-02.eng.bos.redhat.com/devel/stratosphere/azure/RHEL-offers/RHEL-8/RHEL-8.6/",
+        "base-url": "http://download-node-02.eng.bos.redhat.com/devel/stratosphere/azure/RHEL-offers/RHEL-8/RHEL-8.6/",
         "platform-id": "el8",
         "snapshot-id": "el8-x86_64-rhui-azure",
         "storage": "rhvpn"


### PR DESCRIPTION
It seems the Red Hat IT certs are not properly provisioned and all other repositories use http as well.
