### PR TITLE
workflows/scheduled-snapshots: do not update relased fedora repos

### DIFF
--- a/.github/scripts/snapshot_update_pr.sh
+++ b/.github/scripts/snapshot_update_pr.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# This script is meant to be run as a part of a workflow 
+# which sets the necessary environment variables
+
+# run a helper script that updates Schutzfile with new snapshots
+python3 .github/scripts/update_schutzfile.py --repo "$REPO" --suffix "$SUFFIX"
+
+# Open PR with updated Schutzfile
+pushd "$REPO"
+git diff
+git config --unset-all http.https://github.com/.extraheader
+git config user.name "schutzbot"
+git config user.email "schutzbot@gmail.com"
+git checkout -b snapshots-"$SUFFIX"
+git add Schutzfile
+git commit -m "schutzfile: Update snapshots to ${SUFFIX}"
+git push https://"$GITHUB_TOKEN"@github.com/schutzbot/"$REPO".git
+
+cat <<EOF > "body"
+Job(s) succeeded: $JOBS_SUCCEEDED
+Job(s) failed: $JOBS_FAILED
+Workflow run: https://github.com/osbuild/rpmrepo/actions/runs/$WORKFLOW_RUN
+EOF
+
+gh pr create \
+  -t "Update snapshots to $SUFFIX" \
+  -F "body" \
+  --repo "osbuild/$REPO" \
+  --base "main" \
+  --head "schutzbot:snapshots-$SUFFIX"
+popd

--- a/.github/scripts/update_schutzfile.py
+++ b/.github/scripts/update_schutzfile.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python3
+
+"""Required modules"""
+import json
+import os
+import re
+import argparse
+
+
+def main(suffix, repo_folder):
+    """
+    This script is used to update Schutzfile in a speciffic repository. It
+    takes --suffix which specifies which date you want to update the
+    snapshots to and --repo which specifies the repository folder containing
+    Schutzfile.
+    """
+    repo_files = os.listdir("repo/")
+    singletons = []
+    # Get a list of all repositories that contain 'singleton'
+    for repo_file in repo_files:
+        with open(os.path.join("repo", repo_file), "r") as file:
+            data = json.load(file)
+        if "singleton" in data.keys():
+            singletons.append(data["snapshot-id"])
+
+    with open(os.path.join(repo_folder, "Schutzfile"), "r") as file:
+        data = json.load(file)
+
+    # Replace snapshot SUFFIX in repositories that don't have 'singleton' present
+    for key in data.keys():
+        if "repos" in data[key].keys():
+            for repo in data[key]["repos"]:
+                for arch_repos in repo:
+                    for i, _ in enumerate(repo[arch_repos]):
+                        if arch_repos == "file" or any(
+                            singleton in repo[arch_repos][i]["baseurl"]
+                            for singleton in singletons
+                        ):
+                            continue
+                        repo[arch_repos][i]["baseurl"] = re.sub(
+                            "[0-9]{8}",
+                            suffix,
+                            repo[arch_repos][i]["baseurl"],
+                        )
+
+    with open(os.path.join(repo_folder, "Schutzfile"), "w") as file:
+        json.dump(data, file, indent=2)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Updates Schutzfile repositories.")
+    parser.add_argument(
+        "--suffix",
+        metavar="SUFFIX",
+        type=str,
+        help="date of the rpmrepo snapshots",
+        required=True,
+    )
+    parser.add_argument(
+        "--repo",
+        metavar="REPO",
+        type=str,
+        help="repository directory containing Schutzfile",
+        required=True,
+    )
+    args = parser.parse_args()
+    main(args.suffix, args.repo)

--- a/.github/workflows/scheduled-snapshots.yml
+++ b/.github/workflows/scheduled-snapshots.yml
@@ -103,32 +103,29 @@ jobs:
         path: osbuild-composer
         fetch-depth: 0
 
-    - name: Update schutzfile and open PR
+    - name: Update schutzfile and open PR in osbuild-composer repository
       env:
         GITHUB_TOKEN: ${{ secrets.SCHUTZBOT_GH_TOKEN }}
-      run: |
-        pushd osbuild-composer
-        sed -i -E 's/("baseurl": ".*)-[0-9]{8,12}\/?"/\1-${{ steps.generate_suffix.outputs.suffix }}"/g' Schutzfile
-        git diff
-        git config --unset-all http.https://github.com/.extraheader
-        git config user.name "schutzbot"
-        git config user.email "schutzbot@gmail.com"
-        git checkout -b snapshots-${{ steps.generate_suffix.outputs.suffix }}
-        git add Schutzfile
-        git commit -m "schutzfile: Update snapshots to ${{ steps.generate_suffix.outputs.suffix }}"
-        git push https://${{ secrets.SCHUTZBOT_GH_TOKEN }}@github.com/schutzbot/osbuild-composer.git
+        SUFFIX: ${{ steps.generate_suffix.outputs.suffix }}
+        JOBS_SUCCEEDED: ${{ steps.wait_for_jobs-outputs.succeeded }}
+        JOBS_FAILED: ${{ steps.wait_for_jobs.outputs.failed }}
+        WORKFLOW_RUN: ${{ github.run_id }}
+        REPO: "osbuild-composer"
+      run: .github/scripts/snapshot_update_pr.sh
 
-        cat <<EOF > "body"
-        Job(s) succeeded: ${{ steps.wait_for_jobs.outputs.succeeded }}
-        Job(s) failed: ${{ steps.wait_for_jobs.outputs.failed }}
-        Workflow run: https://github.com/osbuild/rpmrepo/actions/runs/${{ github.run_id }}
-        EOF
+    - name: Clone osbuild repository
+      uses: actions/checkout@v2.3.4
+      with:
+        repository: osbuild/osbuild
+        path: osbuild
+        fetch-depth: 0
 
-        gh pr create \
-          -t "Update snapshots to ${{ steps.generate_suffix.outputs.suffix }}" \
-          -F "body" \
-          --repo "osbuild/osbuild-composer" \
-          --base "main" \
-          --head "schutzbot:snapshots-${{ steps.generate_suffix.outputs.suffix }}"
-        popd
-
+    - name: Update schutzfile and open PR in osbuild repository
+      env:
+        GITHUB_TOKEN: ${{ secrets.SCHUTZBOT_GH_TOKEN }}
+        SUFFIX: ${{ steps.generate_suffix.outputs.suffix }}
+        JOBS_SUCCEEDED: ${{ steps.wait_for_jobs-outputs.succeeded }}
+        JOBS_FAILED: ${{ steps.wait_for_jobs.outputs.failed }}
+        WORKFLOW_RUN: ${{ github.run_id }}
+        REPO: "osbuild"
+      run: .github/scripts/snapshot_update_pr.sh


### PR DESCRIPTION
Fedora and fedora-modular repositories don't change so don't update them
when opening a PR with snapshot update.

I also had to switch to perl to be able to use the negative lookbehind. I don't know any better solution this is the first one I've put together with a lot of trial and error and googling. Suggestions more than welcome. This change is needed once https://github.com/osbuild/osbuild-composer/pull/2508 lands to update the snapshots correctly.
