### PR TITLE
repo/rhui-azure: adapt to upstream url changes

### DIFF
--- a/repo/el7-x86_64-rhui-azure.json
+++ b/repo/el7-x86_64-rhui-azure.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download-node-02.eng.bos.redhat.com/devel/stratosphere/azure/RHEL-offers/RHEL-7/Packages/",
+        "base-url": "http://download-node-02.eng.bos.redhat.com/devel/stratosphere/azure/RHEL-offers/RHEL-7",
         "platform-id": "el7",
         "snapshot-id": "el7-x86_64-rhui-azure",
         "storage": "rhvpn"

--- a/repo/el8-x86_64-rhui-azure.json
+++ b/repo/el8-x86_64-rhui-azure.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download.eng.bos.redhat.com/devel/stratosphere/azure/RHEL-offers/RHEL-8/Packages/",
+        "base-url": "http://download.eng.bos.redhat.com/devel/stratosphere/azure/RHEL-offers/RHEL-8/",
         "platform-id": "el8",
         "snapshot-id": "el8-x86_64-rhui-azure",
         "storage": "rhvpn"

--- a/repo/el9-x86_64-rhui-azure.json
+++ b/repo/el9-x86_64-rhui-azure.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download.eng.bos.redhat.com/devel/stratosphere/azure/RHEL-offers/RHEL-9/Packages/",
+        "base-url": "http://download.eng.bos.redhat.com/devel/stratosphere/azure/RHEL-offers/RHEL-9/",
         "platform-id": "el9",
         "snapshot-id": "el9-x86_64-rhui-azure",
         "storage": "rhvpn"


### PR DESCRIPTION
The URL for the synced azure rhui packages changed and we have to follow suit.