### PR TITLE
Verify repository configuration files

### DIFF
--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -29,4 +29,5 @@ jobs:
         python3 -m pylint \
           --disable duplicate-code \
           src/ctl \
-          src/gateway/*.py
+          src/gateway/*.py \
+          src/script/*.py

--- a/.github/workflows/ci-repo.yml
+++ b/.github/workflows/ci-repo.yml
@@ -1,0 +1,30 @@
+#
+# CI Repo Configuration
+#
+# This verifies the formatting of the repository configurations in ./repo/ and
+# tries to verify external references.
+#
+
+name: "CI Repo Configuration"
+
+on:
+  pull_request:
+  push:
+  workflow_dispatch:
+
+jobs:
+  #
+  # Run repo-check.py
+  #
+  repo-check:
+    name: "Repo Configuration Check"
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/osbuild/rpmrepo-ci:latest
+    steps:
+    - name: "Clone Repository"
+      uses: actions/checkout@v2
+    - name: "Run repo-check"
+      run: |
+        ./src/script/repo-check.py ./repo/*.json
+        ./src/script/repo-check.py --check-external public ./repo/*.json

--- a/repo/el7-x86_64-rhui-azure.json
+++ b/repo/el7-x86_64-rhui-azure.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download-node-02.eng.bos.redhat.com/devel/stratosphere/azure/RHEL-offers/RHEL-7",
+        "base-url": "http://download-node-02.eng.bos.redhat.com/devel/stratosphere/azure/RHEL-offers/RHEL-7/",
         "platform-id": "el7",
         "snapshot-id": "el7-x86_64-rhui-azure",
         "storage": "rhvpn"

--- a/repo/el8-x86_64-google-cloud-sdk.json
+++ b/repo/el8-x86_64-google-cloud-sdk.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64",
+        "base-url": "https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64/",
         "platform-id": "el8",
         "snapshot-id": "el8-x86_64-google-cloud-sdk",
         "storage": "public"

--- a/repo/el8-x86_64-google-compute-engine.json
+++ b/repo/el8-x86_64-google-compute-engine.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable",
+        "base-url": "https://packages.cloud.google.com/yum/repos/google-compute-engine-el8-x86_64-stable/",
         "platform-id": "el8",
         "snapshot-id": "el8-x86_64-google-compute-engine",
         "storage": "public"

--- a/repo/el9-x86_64-google-cloud-sdk.json
+++ b/repo/el9-x86_64-google-cloud-sdk.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64",
+        "base-url": "https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64/",
         "platform-id": "el9",
         "snapshot-id": "el9-x86_64-google-cloud-sdk",
         "storage": "public"

--- a/repo/el9-x86_64-google-compute-engine.json
+++ b/repo/el9-x86_64-google-compute-engine.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "https://packages.cloud.google.com/yum/repos/google-compute-engine-el9-x86_64-stable",
+        "base-url": "https://packages.cloud.google.com/yum/repos/google-compute-engine-el9-x86_64-stable/",
         "platform-id": "el9",
         "snapshot-id": "el9-x86_64-google-compute-engine",
         "storage": "public"

--- a/src/script/repo-check.py
+++ b/src/script/repo-check.py
@@ -1,0 +1,167 @@
+#!/usr/bin/python3
+"""repo-check - Check JSON repository files
+
+A simple script to check the validity of repository configuration files that
+we store in ./repo/.
+"""
+
+# pylint: disable=duplicate-code,invalid-name,too-few-public-methods
+
+import argparse
+import json
+import os
+import re
+import urllib.parse
+
+import requests
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        add_help=True,
+        allow_abbrev=False,
+        argument_default=None,
+        description="JSON Repository File Verification",
+        prog="repo-check.py",
+    )
+    parser.add_argument(
+        "--check-external",
+        action="append",
+        help="Verify external references for the given storage type",
+        metavar="STORAGE",
+    )
+    parser.add_argument(
+        "FILES",
+        help="List of files to check",
+        nargs="*",
+        type=os.path.abspath,
+    )
+    parser.set_defaults(check_external=[])
+
+    return parser.parse_args()
+
+
+class Repo:
+    """Repository Configuration"""
+
+    def __init__(self, data):
+        self._data = data
+
+    @classmethod
+    def from_path(cls, path):
+        """Load repository configuration from a file"""
+
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+
+        return cls(data)
+
+    def dump(self):
+        """Dump the configuration to standard output"""
+
+        print(json.dumps(self._data, indent=4, sort_keys=True))
+
+    def storage(self):
+        """Query the storage identifier"""
+
+        return self._data["storage"]
+
+    def _verify_base_url(self):
+        # mandatory
+        assert "base-url" in self._data
+        assert self._data["base-url"]
+
+        # must be a valid URL
+        url = urllib.parse.urlparse(self._data["base-url"])
+        assert url is not None
+
+        # We expect trailing slashes in the URL, as they denote directories
+        # and we want path operations to work without hard-coding this.
+        assert url.path and url.path[-1] == "/"
+
+    def _verify_platform_id(self):
+        # mandatory
+        assert "platform-id" in self._data
+        assert self._data["platform-id"]
+
+        # must be a proper identifier
+        assert re.match(r'^[A-Za-z0-9_-]+$', self._data["platform-id"])
+
+    def _verify_singleton(self):
+        # optional
+        if "singleton" not in self._data:
+            return
+
+        assert self._data["singleton"]
+
+        # must be a proper identifier
+        assert re.match(r'^[A-Za-z0-9_-]+$', self._data["platform-id"])
+
+    def _verify_snapshot_id(self):
+        # mandatory
+        assert "snapshot-id" in self._data
+        assert self._data["snapshot-id"]
+
+        # must be a proper identifier
+        assert re.match(r'^[A-Za-z0-9_-]+$', self._data["platform-id"])
+
+    def _verify_storage(self):
+        # mandatory
+        assert "storage" in self._data
+        assert self._data["storage"]
+
+        # must be a valid storage location
+        assert self._data["storage"] in ["public", "rhvpn"]
+
+    def verify_integrity(self):
+        """Verify integrity of the repository configuration"""
+
+        assert isinstance(self._data, dict)
+
+        for e in self._data:
+            assert isinstance(e, str)
+            assert e in ["base-url", "platform-id", "singleton", "snapshot-id", "storage"]
+
+        self._verify_base_url()
+        self._verify_platform_id()
+        self._verify_singleton()
+        self._verify_snapshot_id()
+        self._verify_storage()
+
+    def _verify_base_url_reference(self):
+        url = urllib.parse.urlparse(self._data["base-url"])
+        url = url._replace(path=urllib.parse.urljoin(url.path, "repodata/repomd.xml"))
+
+        h = requests.head(urllib.parse.urlunparse(url))
+        if h.status_code != 200:
+            raise ValueError(f"Cannot fetch repomd.xml: {urllib.parse.urlunparse(url)} {h}")
+
+    def verify_references(self):
+        """Verify references to external resources"""
+
+        self._verify_base_url_reference()
+
+
+def main():
+    """Script Entrypoint"""
+
+    args = _parse_args()
+
+    print("------------------------")
+    for f in args.FILES:
+        print("Loading file:", f)
+        r = Repo.from_path(f)
+
+        print("Contents:")
+        r.dump()
+
+        r.verify_integrity()
+
+        if r.storage in args.check_external:
+            r.verify_references()
+
+        print("------------------------")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add a new script called `repo-check.py` which reads repository configuration files from ./repo/*.json and verifies their integrity. The script takes a list of files to parse. It always parses the respective JSON file, verifies all keys for some basic properties, and prints them to standard output.

Optionally, it also checks external URLs (in our case the Base-URL) for validity. However, this requires passing `--check-external <storage>`, to make it check URLs of the specified storage class. Since RHVPN URLs cannot be accessed from the github CI, we only check the public URLs.