### PR TITLE
repo: add jboss EAP repos for RHEL 7, 8, and 9

### DIFF
--- a/repo/el7-x86_64-jbeap7.json
+++ b/repo/el7-x86_64-jbeap7.json
@@ -1,0 +1,6 @@
+{
+  "base-url": "http://download.eng.bos.redhat.com/released/jboss/eap7/latest-released/JBEAP-7-RHEL-7/Server/x86_64/os/",
+  "platform-id": "el7",
+  "snapshot-id": "el7-x86_64-jbeap7",
+  "storage": "rhvpn"
+}

--- a/repo/el8-x86_64-jbeap7.json
+++ b/repo/el8-x86_64-jbeap7.json
@@ -1,0 +1,6 @@
+{
+  "base-url": "http://download.eng.bos.redhat.com/released/jboss/eap7/latest-released/JBEAP-7-RHEL-8/Server/x86_64/os/",
+  "platform-id": "el8",
+  "snapshot-id": "el8-x86_64-jbeap7",
+  "storage": "rhvpn"
+}

--- a/repo/el9-x86_64-jbeap7.json
+++ b/repo/el9-x86_64-jbeap7.json
@@ -1,0 +1,6 @@
+{
+  "base-url": "http://download.eng.bos.redhat.com/released/jboss/eap7/latest-released/JBEAP-7-RHEL-9/Server/x86_64/os/",
+  "platform-id": "el9",
+  "snapshot-id": "el9-x86_64-jbeap7",
+  "storage": "rhvpn"
+}


### PR DESCRIPTION
Adding new repos for building EAP images for all major RHEL versions.
See [this comment][repourls] on the [relevant ticket][ticketurl] for the source of the URLs.

[repourls]: https://issues.redhat.com/browse/COMPOSER-1504?focusedCommentId=21357327&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-21357327
[ticketurl]: https://issues.redhat.com/browse/COMPOSER-1504