### PR TITLE
Delete F35 repos, since it is EOL

### DIFF
--- a/repo/f35-aarch64-fedora-modular.json
+++ b/repo/f35-aarch64-fedora-modular.json
@@ -1,7 +1,0 @@
-{
-        "base-url": "https://dl01.fedoraproject.org/pub/fedora/linux/releases/35/Modular/aarch64/os/",
-        "platform-id": "f35",
-        "singleton": "20220106",
-        "snapshot-id": "f35-aarch64-fedora-modular",
-        "storage": "public"
-}

--- a/repo/f35-aarch64-fedora.json
+++ b/repo/f35-aarch64-fedora.json
@@ -1,7 +1,0 @@
-{
-        "base-url": "https://dl01.fedoraproject.org/pub/fedora/linux/releases/35/Everything/aarch64/os/",
-        "platform-id": "f35",
-        "singleton": "20220106",
-        "snapshot-id": "f35-aarch64-fedora",
-        "storage": "public"
-}

--- a/repo/f35-aarch64-updates-released-modular.json
+++ b/repo/f35-aarch64-updates-released-modular.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "https://dl01.fedoraproject.org/pub/fedora/linux/updates/35/Modular/aarch64/",
-        "platform-id": "f35",
-        "snapshot-id": "f35-aarch64-updates-released-modular",
-        "storage": "public"
-}

--- a/repo/f35-aarch64-updates-released.json
+++ b/repo/f35-aarch64-updates-released.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "https://dl01.fedoraproject.org/pub/fedora/linux/updates/35/Everything/aarch64/",
-        "platform-id": "f35",
-        "snapshot-id": "f35-aarch64-updates-released",
-        "storage": "public"
-}

--- a/repo/f35-x86_64-fedora-modular.json
+++ b/repo/f35-x86_64-fedora-modular.json
@@ -1,7 +1,0 @@
-{
-        "base-url": "https://dl01.fedoraproject.org/pub/fedora/linux/releases/35/Modular/x86_64/os/",
-        "platform-id": "f35",
-        "singleton": "20220106",
-        "snapshot-id": "f35-x86_64-fedora-modular",
-        "storage": "public"
-}

--- a/repo/f35-x86_64-fedora.json
+++ b/repo/f35-x86_64-fedora.json
@@ -1,7 +1,0 @@
-{
-        "base-url": "https://dl01.fedoraproject.org/pub/fedora/linux/releases/35/Everything/x86_64/os/",
-        "platform-id": "f35",
-        "singleton": "20220106",
-        "snapshot-id": "f35-x86_64-fedora",
-        "storage": "public"
-}

--- a/repo/f35-x86_64-updates-released-modular.json
+++ b/repo/f35-x86_64-updates-released-modular.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "https://dl01.fedoraproject.org/pub/fedora/linux/updates/35/Modular/x86_64/",
-        "platform-id": "f35",
-        "snapshot-id": "f35-x86_64-updates-released-modular",
-        "storage": "public"
-}

--- a/repo/f35-x86_64-updates-released.json
+++ b/repo/f35-x86_64-updates-released.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "https://dl01.fedoraproject.org/pub/fedora/linux/updates/35/Everything/x86_64/",
-        "platform-id": "f35",
-        "snapshot-id": "f35-x86_64-updates-released",
-        "storage": "public"
-}


### PR DESCRIPTION
F35 is EOL. The URLs for its repositories are already not available. Delete all of them.