### PR TITLE
Update URLs for Azure RHUI client RPM mirrors

### DIFF
--- a/repo-definitions.yaml
+++ b/repo-definitions.yaml
@@ -29,7 +29,7 @@ rhel:
 - release: '7.9'
   arch:
     - x86_64
-  base_url: http://download-node-02.eng.bos.redhat.com/devel/stratosphere/azure/RHEL-offers/RHEL-7/
+  base_url: http://download.eng.bos.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel7/
   snapshot_id_suffix: rhui-azure
 - release: '7.9'
   arch:
@@ -78,12 +78,12 @@ rhel:
 - release: '8.0'
   arch:
     - x86_64
-  base_url: http://download.eng.bos.redhat.com/devel/stratosphere/azure/RHEL-offers/RHEL-8/
+  base_url: http://download.eng.bos.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel8/
   snapshot_id_suffix: rhui-azure
 - release: '8.0'
   arch:
     - x86_64
-  base_url: http://download-node-02.eng.bos.redhat.com/devel/stratosphere/azure/RHEL-offers/RHEL-9-SAP-HA/
+  base_url: http://download.eng.bos.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel8-sap-ha/
   snapshot_id_suffix: sap-rhui-azure
 - release: '8.0'
   arch:
@@ -184,7 +184,7 @@ rhel:
 - release: '9.0'
   arch:
     - x86_64
-  base_url: http://download.eng.bos.redhat.com/devel/stratosphere/azure/RHEL-offers/RHEL-9/
+  base_url: http://download.eng.bos.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel9/
   snapshot_id_suffix: rhui-azure
 - release: '9.0'
   arch:

--- a/repo/el7-x86_64-rhui-azure.json
+++ b/repo/el7-x86_64-rhui-azure.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download-node-02.eng.bos.redhat.com/devel/stratosphere/azure/RHEL-offers/RHEL-7/",
+        "base-url": "http://download.eng.bos.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel7/",
         "platform-id": "el7",
         "snapshot-id": "el7-x86_64-rhui-azure",
         "storage": "rhvpn"

--- a/repo/el8-x86_64-rhui-azure.json
+++ b/repo/el8-x86_64-rhui-azure.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download.eng.bos.redhat.com/devel/stratosphere/azure/RHEL-offers/RHEL-8/",
+        "base-url": "http://download.eng.bos.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel8/",
         "platform-id": "el8",
         "snapshot-id": "el8-x86_64-rhui-azure",
         "storage": "rhvpn"

--- a/repo/el8-x86_64-sap-rhui-azure.json
+++ b/repo/el8-x86_64-sap-rhui-azure.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download-node-02.eng.bos.redhat.com/devel/stratosphere/azure/RHEL-offers/RHEL-9-SAP-HA/",
+        "base-url": "http://download.eng.bos.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel8-sap-ha/",
         "platform-id": "el8",
         "snapshot-id": "el8-x86_64-sap-rhui-azure",
         "storage": "rhvpn"

--- a/repo/el9-x86_64-rhui-azure.json
+++ b/repo/el9-x86_64-rhui-azure.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download.eng.bos.redhat.com/devel/stratosphere/azure/RHEL-offers/RHEL-9/",
+        "base-url": "http://download.eng.bos.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel9/",
         "platform-id": "el9",
         "snapshot-id": "el9-x86_64-rhui-azure",
         "storage": "rhvpn"


### PR DESCRIPTION
The old URLs are not updated any more and contain very old packages.