### PR TITLE
mark all static repositories as singletons

### DIFF
--- a/repo-definitions.yaml
+++ b/repo-definitions.yaml
@@ -22,6 +22,7 @@ rhel:
   base_url: http://download.eng.bos.redhat.com/rhel-7/rel-eng/EXTRAS-7/latest-EXTRAS-7.9-RHEL-7/compose/Server/x86_64/os/
   snapshot_id_suffix: server-extras-r7.9
 - release: '7.9'
+  singleton: '20230809'
   arch:
     - x86_64
   base_url: http://download.eng.bos.redhat.com/rhel-7/rel-eng/dotNET-1.1-RHEL-7-20161128.0/compose/Server/x86_64/os/
@@ -51,6 +52,7 @@ rhel:
   arch:
     - x86_64
   released: true
+  singleton: '20230809'
   repo_name:
     - Server
     - Server-SAP
@@ -106,11 +108,13 @@ rhel:
 # Snapshots of RHEL-8.2 repos
 - release: '8.2'
   released: true
+  singleton: '20230809'
   repo_name:
     - BaseOS
     - AppStream
 - release: '8.2'
   released: true
+  singleton: '20230809'
   arch:
     - x86_64
   repo_name:
@@ -118,11 +122,13 @@ rhel:
 # Snapshots of RHEL-8.3 repos
 - release: '8.3'
   released: true
+  singleton: '20230809'
   repo_name:
     - BaseOS
     - AppStream
 - release: '8.3'
   released: true
+  singleton: '20230809'
   arch:
     - x86_64
   repo_name:
@@ -130,11 +136,13 @@ rhel:
 # Snapshots of RHEL-8.4 repos
 - release: '8.4'
   released: true
+  singleton: '20230809'
   repo_name:
     - BaseOS
     - AppStream
 - release: '8.4'
   released: true
+  singleton: '20230809'
   arch:
     - x86_64
   repo_name:
@@ -145,11 +153,13 @@ rhel:
 # Snapshots of RHEL-8.5 repos
 - release: '8.5'
   released: true
+  singleton: '20230809'
   repo_name:
     - BaseOS
     - AppStream
 - release: '8.5'
   released: true
+  singleton: '20230809'
   arch:
     - x86_64
   repo_name:
@@ -159,6 +169,7 @@ rhel:
 # Snapshots of RHEL-8.6 repos
 - release: '8.6'
   released: true
+  singleton: '20230809'
   arch:
     - x86_64
   repo_name:

--- a/repo/el7-x86_64-server-dotnet-r1.1.json
+++ b/repo/el7-x86_64-server-dotnet-r1.1.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-7/rel-eng/dotNET-1.1-RHEL-7-20161128.0/compose/Server/x86_64/os/",
         "platform-id": "el7",
+        "singleton": "20230809",
         "snapshot-id": "el7-x86_64-server-dotnet-r1.1",
         "storage": "rhvpn"
 }

--- a/repo/el7-x86_64-server-optional-r7.9.json
+++ b/repo/el7-x86_64-server-optional-r7.9.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-7/rel-eng/RHEL-7/latest-RHEL-7.9/compose/Server-optional/x86_64/os/",
         "platform-id": "el7",
+        "singleton": "20230809",
         "snapshot-id": "el7-x86_64-server-optional-r7.9",
         "storage": "rhvpn"
 }

--- a/repo/el7-x86_64-server-r7.9.json
+++ b/repo/el7-x86_64-server-r7.9.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-7/rel-eng/RHEL-7/latest-RHEL-7.9/compose/Server/x86_64/os/",
         "platform-id": "el7",
+        "singleton": "20230809",
         "snapshot-id": "el7-x86_64-server-r7.9",
         "storage": "rhvpn"
 }

--- a/repo/el7-x86_64-server-rt-r7.9.json
+++ b/repo/el7-x86_64-server-rt-r7.9.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-7/rel-eng/RHEL-7/latest-RHEL-7.9/compose/Server-RT/x86_64/os/",
         "platform-id": "el7",
+        "singleton": "20230809",
         "snapshot-id": "el7-x86_64-server-rt-r7.9",
         "storage": "rhvpn"
 }

--- a/repo/el7-x86_64-server-sap-r7.9.json
+++ b/repo/el7-x86_64-server-sap-r7.9.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-7/rel-eng/RHEL-7/latest-RHEL-7.9/compose/Server-SAP/x86_64/os/",
         "platform-id": "el7",
+        "singleton": "20230809",
         "snapshot-id": "el7-x86_64-server-sap-r7.9",
         "storage": "rhvpn"
 }

--- a/repo/el8-aarch64-appstream-r8.2.json
+++ b/repo/el8-aarch64-appstream-r8.2.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.2/compose/AppStream/aarch64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-aarch64-appstream-r8.2",
         "storage": "rhvpn"
 }

--- a/repo/el8-aarch64-appstream-r8.3.json
+++ b/repo/el8-aarch64-appstream-r8.3.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.3/compose/AppStream/aarch64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-aarch64-appstream-r8.3",
         "storage": "rhvpn"
 }

--- a/repo/el8-aarch64-appstream-r8.4.json
+++ b/repo/el8-aarch64-appstream-r8.4.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.4/compose/AppStream/aarch64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-aarch64-appstream-r8.4",
         "storage": "rhvpn"
 }

--- a/repo/el8-aarch64-appstream-r8.5.json
+++ b/repo/el8-aarch64-appstream-r8.5.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5/compose/AppStream/aarch64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-aarch64-appstream-r8.5",
         "storage": "rhvpn"
 }

--- a/repo/el8-aarch64-baseos-r8.2.json
+++ b/repo/el8-aarch64-baseos-r8.2.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.2/compose/BaseOS/aarch64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-aarch64-baseos-r8.2",
         "storage": "rhvpn"
 }

--- a/repo/el8-aarch64-baseos-r8.3.json
+++ b/repo/el8-aarch64-baseos-r8.3.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.3/compose/BaseOS/aarch64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-aarch64-baseos-r8.3",
         "storage": "rhvpn"
 }

--- a/repo/el8-aarch64-baseos-r8.4.json
+++ b/repo/el8-aarch64-baseos-r8.4.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.4/compose/BaseOS/aarch64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-aarch64-baseos-r8.4",
         "storage": "rhvpn"
 }

--- a/repo/el8-aarch64-baseos-r8.5.json
+++ b/repo/el8-aarch64-baseos-r8.5.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5/compose/BaseOS/aarch64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-aarch64-baseos-r8.5",
         "storage": "rhvpn"
 }

--- a/repo/el8-ppc64le-appstream-r8.2.json
+++ b/repo/el8-ppc64le-appstream-r8.2.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.2/compose/AppStream/ppc64le/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-ppc64le-appstream-r8.2",
         "storage": "rhvpn"
 }

--- a/repo/el8-ppc64le-appstream-r8.3.json
+++ b/repo/el8-ppc64le-appstream-r8.3.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.3/compose/AppStream/ppc64le/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-ppc64le-appstream-r8.3",
         "storage": "rhvpn"
 }

--- a/repo/el8-ppc64le-appstream-r8.4.json
+++ b/repo/el8-ppc64le-appstream-r8.4.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.4/compose/AppStream/ppc64le/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-ppc64le-appstream-r8.4",
         "storage": "rhvpn"
 }

--- a/repo/el8-ppc64le-appstream-r8.5.json
+++ b/repo/el8-ppc64le-appstream-r8.5.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5/compose/AppStream/ppc64le/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-ppc64le-appstream-r8.5",
         "storage": "rhvpn"
 }

--- a/repo/el8-ppc64le-baseos-r8.2.json
+++ b/repo/el8-ppc64le-baseos-r8.2.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.2/compose/BaseOS/ppc64le/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-ppc64le-baseos-r8.2",
         "storage": "rhvpn"
 }

--- a/repo/el8-ppc64le-baseos-r8.3.json
+++ b/repo/el8-ppc64le-baseos-r8.3.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.3/compose/BaseOS/ppc64le/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-ppc64le-baseos-r8.3",
         "storage": "rhvpn"
 }

--- a/repo/el8-ppc64le-baseos-r8.4.json
+++ b/repo/el8-ppc64le-baseos-r8.4.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.4/compose/BaseOS/ppc64le/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-ppc64le-baseos-r8.4",
         "storage": "rhvpn"
 }

--- a/repo/el8-ppc64le-baseos-r8.5.json
+++ b/repo/el8-ppc64le-baseos-r8.5.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5/compose/BaseOS/ppc64le/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-ppc64le-baseos-r8.5",
         "storage": "rhvpn"
 }

--- a/repo/el8-s390x-appstream-r8.2.json
+++ b/repo/el8-s390x-appstream-r8.2.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.2/compose/AppStream/s390x/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-s390x-appstream-r8.2",
         "storage": "rhvpn"
 }

--- a/repo/el8-s390x-appstream-r8.3.json
+++ b/repo/el8-s390x-appstream-r8.3.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.3/compose/AppStream/s390x/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-s390x-appstream-r8.3",
         "storage": "rhvpn"
 }

--- a/repo/el8-s390x-appstream-r8.4.json
+++ b/repo/el8-s390x-appstream-r8.4.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.4/compose/AppStream/s390x/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-s390x-appstream-r8.4",
         "storage": "rhvpn"
 }

--- a/repo/el8-s390x-appstream-r8.5.json
+++ b/repo/el8-s390x-appstream-r8.5.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5/compose/AppStream/s390x/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-s390x-appstream-r8.5",
         "storage": "rhvpn"
 }

--- a/repo/el8-s390x-baseos-r8.2.json
+++ b/repo/el8-s390x-baseos-r8.2.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.2/compose/BaseOS/s390x/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-s390x-baseos-r8.2",
         "storage": "rhvpn"
 }

--- a/repo/el8-s390x-baseos-r8.3.json
+++ b/repo/el8-s390x-baseos-r8.3.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.3/compose/BaseOS/s390x/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-s390x-baseos-r8.3",
         "storage": "rhvpn"
 }

--- a/repo/el8-s390x-baseos-r8.4.json
+++ b/repo/el8-s390x-baseos-r8.4.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.4/compose/BaseOS/s390x/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-s390x-baseos-r8.4",
         "storage": "rhvpn"
 }

--- a/repo/el8-s390x-baseos-r8.5.json
+++ b/repo/el8-s390x-baseos-r8.5.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5/compose/BaseOS/s390x/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-s390x-baseos-r8.5",
         "storage": "rhvpn"
 }

--- a/repo/el8-x86_64-appstream-r8.2.json
+++ b/repo/el8-x86_64-appstream-r8.2.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.2/compose/AppStream/x86_64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-x86_64-appstream-r8.2",
         "storage": "rhvpn"
 }

--- a/repo/el8-x86_64-appstream-r8.3.json
+++ b/repo/el8-x86_64-appstream-r8.3.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.3/compose/AppStream/x86_64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-x86_64-appstream-r8.3",
         "storage": "rhvpn"
 }

--- a/repo/el8-x86_64-appstream-r8.4.json
+++ b/repo/el8-x86_64-appstream-r8.4.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.4/compose/AppStream/x86_64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-x86_64-appstream-r8.4",
         "storage": "rhvpn"
 }

--- a/repo/el8-x86_64-appstream-r8.5.json
+++ b/repo/el8-x86_64-appstream-r8.5.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5/compose/AppStream/x86_64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-x86_64-appstream-r8.5",
         "storage": "rhvpn"
 }

--- a/repo/el8-x86_64-baseos-r8.2.json
+++ b/repo/el8-x86_64-baseos-r8.2.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.2/compose/BaseOS/x86_64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-x86_64-baseos-r8.2",
         "storage": "rhvpn"
 }

--- a/repo/el8-x86_64-baseos-r8.3.json
+++ b/repo/el8-x86_64-baseos-r8.3.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.3/compose/BaseOS/x86_64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-x86_64-baseos-r8.3",
         "storage": "rhvpn"
 }

--- a/repo/el8-x86_64-baseos-r8.4.json
+++ b/repo/el8-x86_64-baseos-r8.4.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.4/compose/BaseOS/x86_64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-x86_64-baseos-r8.4",
         "storage": "rhvpn"
 }

--- a/repo/el8-x86_64-baseos-r8.5.json
+++ b/repo/el8-x86_64-baseos-r8.5.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5/compose/BaseOS/x86_64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-x86_64-baseos-r8.5",
         "storage": "rhvpn"
 }

--- a/repo/el8-x86_64-ha-r8.4.json
+++ b/repo/el8-x86_64-ha-r8.4.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.4/compose/HighAvailability/x86_64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-x86_64-ha-r8.4",
         "storage": "rhvpn"
 }

--- a/repo/el8-x86_64-ha-r8.5.json
+++ b/repo/el8-x86_64-ha-r8.5.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5/compose/HighAvailability/x86_64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-x86_64-ha-r8.5",
         "storage": "rhvpn"
 }

--- a/repo/el8-x86_64-rt-r8.2.json
+++ b/repo/el8-x86_64-rt-r8.2.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.2/compose/RT/x86_64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-x86_64-rt-r8.2",
         "storage": "rhvpn"
 }

--- a/repo/el8-x86_64-rt-r8.3.json
+++ b/repo/el8-x86_64-rt-r8.3.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.3/compose/RT/x86_64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-x86_64-rt-r8.3",
         "storage": "rhvpn"
 }

--- a/repo/el8-x86_64-rt-r8.4.json
+++ b/repo/el8-x86_64-rt-r8.4.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.4/compose/RT/x86_64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-x86_64-rt-r8.4",
         "storage": "rhvpn"
 }

--- a/repo/el8-x86_64-rt-r8.5.json
+++ b/repo/el8-x86_64-rt-r8.5.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5/compose/RT/x86_64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-x86_64-rt-r8.5",
         "storage": "rhvpn"
 }

--- a/repo/el8-x86_64-sap-r8.4.json
+++ b/repo/el8-x86_64-sap-r8.4.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.4/compose/SAP/x86_64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-x86_64-sap-r8.4",
         "storage": "rhvpn"
 }

--- a/repo/el8-x86_64-saphana-r8.4.json
+++ b/repo/el8-x86_64-saphana-r8.4.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.4/compose/SAPHANA/x86_64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-x86_64-saphana-r8.4",
         "storage": "rhvpn"
 }

--- a/repo/el8-x86_64-saphana-r8.5.json
+++ b/repo/el8-x86_64-saphana-r8.5.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.5/compose/SAPHANA/x86_64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-x86_64-saphana-r8.5",
         "storage": "rhvpn"
 }

--- a/repo/el8-x86_64-saphana-r8.6.json
+++ b/repo/el8-x86_64-saphana-r8.6.json
@@ -1,6 +1,7 @@
 {
         "base-url": "http://download.eng.bos.redhat.com/rhel-8/rel-eng/RHEL-8/latest-RHEL-8.6/compose/SAPHANA/x86_64/os/",
         "platform-id": "el8",
+        "singleton": "20230809",
         "snapshot-id": "el8-x86_64-saphana-r8.6",
         "storage": "rhvpn"
 }


### PR DESCRIPTION
All EL8 "latest-RHEL-*" composes under rel-eng seem to be static - they never change. It's hard to find a definite documentation on this matter, but I think they are simply the "golden" RC composes.

Thus, let's mark them as singleton with today's date in order to make one last snapshot and then stop making them so we don't waste resources.

The same is true for EL7. For dotNET-1.1-RHEL-7-20161128.0... 😅