### PR TITLE
github: Check updated Schutzfile's snapshots

### DIFF
--- a/.github/scripts/snapshot_update_pr.sh
+++ b/.github/scripts/snapshot_update_pr.sh
@@ -6,8 +6,14 @@
 # run a helper script that updates Schutzfile with new snapshots
 python3 .github/scripts/update_schutzfile.py --repo "$REPO" --suffix "$SUFFIX"
 
+pushd "$REPO" || exit 2
+
+if [ -e ./tools/check-snapshots ]; then
+    echo "Checking snapshots..."
+    ./tools/check-snapshots --errors-only . || exit 1
+fi
+
 # Open PR with updated Schutzfile
-pushd "$REPO"
 git diff
 git config --unset-all http.https://github.com/.extraheader
 git config user.name "schutzbot"
@@ -29,4 +35,4 @@ gh pr create \
   --repo "osbuild/$REPO" \
   --base "main" \
   --head "schutzbot:snapshots-$SUFFIX"
-popd
+popd || exit 2


### PR DESCRIPTION
The update_schutzfile.py script just substitutes new dates for the old ones, which can result in incorrect snapshots if one or more of them have been removed.

This patch runs the check-snapshot script from the $REPO being modified, checking to make sure all the new snapshots are available.

If they are not, it exits with a 1. The upstream Schutzfile will need to be changed to remove the missing snapshots (or the script needs to be modified to leave them at their final date -- but that's a subject for another patch).