### PR TITLE
Fedora: snapshot ppc64le and s390x repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ help:
 	@echo "targets are available:"
 	@echo
 	@echo "    help:               Print this usage information."
+	@echo "    snapshot-configs:   Regenerate all snapshot configs from definitions."
 
 $(BUILDDIR)/:
 	$(BIN_MKDIR) -p "$@"

--- a/gen-repos.py
+++ b/gen-repos.py
@@ -220,6 +220,8 @@ class FedoraRepoConfigGenerator(BaseRepoConfigGenerator):
 
     FEDORA_BASE_URL_TEMPLATE = "https://dl01.fedoraproject.org/pub/fedora/linux/{stream}/{stream_release}/" + \
                                "{repo_name}/{arch}/os/"
+    FEDORA_SECONDARY_BASE_URL_TEMPLATE = "https://dl.fedoraproject.org/pub/fedora-secondary/{stream}/" + \
+                                         "{stream_release}/{repo_name}/{arch}/os/"
     RELEASE_STREAM = ['releases', 'updates', 'development', 'rawhide']
 
     # pylint: disable=too-many-arguments
@@ -232,7 +234,7 @@ class FedoraRepoConfigGenerator(BaseRepoConfigGenerator):
 
     @staticmethod
     def default_arches(release):
-        return ['x86_64', 'aarch64']
+        return ['x86_64', 'aarch64', 'ppc64le', 's390x']
 
     @staticmethod
     def default_repo_names(arch, release):
@@ -249,7 +251,11 @@ class FedoraRepoConfigGenerator(BaseRepoConfigGenerator):
             stream = self.stream
             stream_release = self.release
 
-        url = self.FEDORA_BASE_URL_TEMPLATE.format(
+        template = self.FEDORA_BASE_URL_TEMPLATE
+        if self.arch in ['ppc64le', 's390x']:
+            template = self.FEDORA_SECONDARY_BASE_URL_TEMPLATE
+
+        url = template.format(
             stream=stream,
             stream_release=stream_release,
             repo_name=self.repo_name,

--- a/repo/f37-ppc64le-fedora-modular.json
+++ b/repo/f37-ppc64le-fedora-modular.json
@@ -1,0 +1,7 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/releases/37/Modular/ppc64le/os/",
+        "platform-id": "f37",
+        "singleton": "20221124",
+        "snapshot-id": "f37-ppc64le-fedora-modular",
+        "storage": "public"
+}

--- a/repo/f37-ppc64le-fedora.json
+++ b/repo/f37-ppc64le-fedora.json
@@ -1,0 +1,7 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/releases/37/Everything/ppc64le/os/",
+        "platform-id": "f37",
+        "singleton": "20221124",
+        "snapshot-id": "f37-ppc64le-fedora",
+        "storage": "public"
+}

--- a/repo/f37-ppc64le-updates-released-modular.json
+++ b/repo/f37-ppc64le-updates-released-modular.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/updates/37/Modular/ppc64le/",
+        "platform-id": "f37",
+        "snapshot-id": "f37-ppc64le-updates-released-modular",
+        "storage": "public"
+}

--- a/repo/f37-ppc64le-updates-released.json
+++ b/repo/f37-ppc64le-updates-released.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/updates/37/Everything/ppc64le/",
+        "platform-id": "f37",
+        "snapshot-id": "f37-ppc64le-updates-released",
+        "storage": "public"
+}

--- a/repo/f37-s390x-fedora-modular.json
+++ b/repo/f37-s390x-fedora-modular.json
@@ -1,0 +1,7 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/releases/37/Modular/s390x/os/",
+        "platform-id": "f37",
+        "singleton": "20221124",
+        "snapshot-id": "f37-s390x-fedora-modular",
+        "storage": "public"
+}

--- a/repo/f37-s390x-fedora.json
+++ b/repo/f37-s390x-fedora.json
@@ -1,0 +1,7 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/releases/37/Everything/s390x/os/",
+        "platform-id": "f37",
+        "singleton": "20221124",
+        "snapshot-id": "f37-s390x-fedora",
+        "storage": "public"
+}

--- a/repo/f37-s390x-updates-released-modular.json
+++ b/repo/f37-s390x-updates-released-modular.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/updates/37/Modular/s390x/",
+        "platform-id": "f37",
+        "snapshot-id": "f37-s390x-updates-released-modular",
+        "storage": "public"
+}

--- a/repo/f37-s390x-updates-released.json
+++ b/repo/f37-s390x-updates-released.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/updates/37/Everything/s390x/",
+        "platform-id": "f37",
+        "snapshot-id": "f37-s390x-updates-released",
+        "storage": "public"
+}

--- a/repo/f38-ppc64le-fedora-modular.json
+++ b/repo/f38-ppc64le-fedora-modular.json
@@ -1,0 +1,7 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/releases/38/Modular/ppc64le/os/",
+        "platform-id": "f38",
+        "singleton": "20230413",
+        "snapshot-id": "f38-ppc64le-fedora-modular",
+        "storage": "public"
+}

--- a/repo/f38-ppc64le-fedora.json
+++ b/repo/f38-ppc64le-fedora.json
@@ -1,0 +1,7 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/releases/38/Everything/ppc64le/os/",
+        "platform-id": "f38",
+        "singleton": "20230413",
+        "snapshot-id": "f38-ppc64le-fedora",
+        "storage": "public"
+}

--- a/repo/f38-ppc64le-updates-released-modular.json
+++ b/repo/f38-ppc64le-updates-released-modular.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/updates/38/Modular/ppc64le/",
+        "platform-id": "f38",
+        "snapshot-id": "f38-ppc64le-updates-released-modular",
+        "storage": "public"
+}

--- a/repo/f38-ppc64le-updates-released.json
+++ b/repo/f38-ppc64le-updates-released.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/updates/38/Everything/ppc64le/",
+        "platform-id": "f38",
+        "snapshot-id": "f38-ppc64le-updates-released",
+        "storage": "public"
+}

--- a/repo/f38-s390x-fedora-modular.json
+++ b/repo/f38-s390x-fedora-modular.json
@@ -1,0 +1,7 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/releases/38/Modular/s390x/os/",
+        "platform-id": "f38",
+        "singleton": "20230413",
+        "snapshot-id": "f38-s390x-fedora-modular",
+        "storage": "public"
+}

--- a/repo/f38-s390x-fedora.json
+++ b/repo/f38-s390x-fedora.json
@@ -1,0 +1,7 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/releases/38/Everything/s390x/os/",
+        "platform-id": "f38",
+        "singleton": "20230413",
+        "snapshot-id": "f38-s390x-fedora",
+        "storage": "public"
+}

--- a/repo/f38-s390x-updates-released-modular.json
+++ b/repo/f38-s390x-updates-released-modular.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/updates/38/Modular/s390x/",
+        "platform-id": "f38",
+        "snapshot-id": "f38-s390x-updates-released-modular",
+        "storage": "public"
+}

--- a/repo/f38-s390x-updates-released.json
+++ b/repo/f38-s390x-updates-released.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/updates/38/Everything/s390x/",
+        "platform-id": "f38",
+        "snapshot-id": "f38-s390x-updates-released",
+        "storage": "public"
+}

--- a/repo/f39-ppc64le-branched.json
+++ b/repo/f39-ppc64le-branched.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/development/39/Everything/ppc64le/os/",
+        "platform-id": "f39",
+        "snapshot-id": "f39-ppc64le-branched",
+        "storage": "public"
+}

--- a/repo/f39-s390x-branched.json
+++ b/repo/f39-s390x-branched.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/development/39/Everything/s390x/os/",
+        "platform-id": "f39",
+        "snapshot-id": "f39-s390x-branched",
+        "storage": "public"
+}

--- a/repo/f40-ppc64le-rawhide.json
+++ b/repo/f40-ppc64le-rawhide.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/development/rawhide/Everything/ppc64le/os/",
+        "platform-id": "f40",
+        "snapshot-id": "f40-ppc64le-rawhide",
+        "storage": "public"
+}

--- a/repo/f40-s390x-rawhide.json
+++ b/repo/f40-s390x-rawhide.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/development/rawhide/Everything/s390x/os/",
+        "platform-id": "f40",
+        "snapshot-id": "f40-s390x-rawhide",
+        "storage": "public"
+}


### PR DESCRIPTION
This will be helpful for testing base s390x and ppc64le support in the images repository by generating manifests.