### PR TITLE
Add support for Fedora ELN repositories

### DIFF
--- a/gen-all-repos.py
+++ b/gen-all-repos.py
@@ -94,8 +94,9 @@ def main():
             cmd.append(distro)
 
             # DISTRO SPECIFIC OPTIONS
-            release = repo['release']
-            cmd.extend(['--release', release])
+            if distro != 'eln':
+                release = repo['release']
+                cmd.extend(['--release', release])
 
             if distro == 'rhel':
                 released = repo.get('released', False)

--- a/repo-definitions.yaml
+++ b/repo-definitions.yaml
@@ -255,3 +255,8 @@ fedora:
 # rawhide
 - release: '40'
   stream: rawhide
+
+# Fedora ELN
+eln:
+  - dummy:
+      # This needs to be an object, so let's just put a dummy one here.

--- a/repo/eln-aarch64-appstream.json
+++ b/repo/eln-aarch64-appstream.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/AppStream/aarch64/os/",
+        "platform-id": "eln",
+        "snapshot-id": "eln-aarch64-appstream",
+        "storage": "public"
+}

--- a/repo/eln-aarch64-baseos.json
+++ b/repo/eln-aarch64-baseos.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/BaseOS/aarch64/os/",
+        "platform-id": "eln",
+        "snapshot-id": "eln-aarch64-baseos",
+        "storage": "public"
+}

--- a/repo/eln-aarch64-crb.json
+++ b/repo/eln-aarch64-crb.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/CRB/aarch64/os/",
+        "platform-id": "eln",
+        "snapshot-id": "eln-aarch64-crb",
+        "storage": "public"
+}

--- a/repo/eln-ppc64le-appstream.json
+++ b/repo/eln-ppc64le-appstream.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/AppStream/ppc64le/os/",
+        "platform-id": "eln",
+        "snapshot-id": "eln-ppc64le-appstream",
+        "storage": "public"
+}

--- a/repo/eln-ppc64le-baseos.json
+++ b/repo/eln-ppc64le-baseos.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/BaseOS/ppc64le/os/",
+        "platform-id": "eln",
+        "snapshot-id": "eln-ppc64le-baseos",
+        "storage": "public"
+}

--- a/repo/eln-ppc64le-crb.json
+++ b/repo/eln-ppc64le-crb.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/CRB/ppc64le/os/",
+        "platform-id": "eln",
+        "snapshot-id": "eln-ppc64le-crb",
+        "storage": "public"
+}

--- a/repo/eln-s390x-appstream.json
+++ b/repo/eln-s390x-appstream.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/AppStream/s390x/os/",
+        "platform-id": "eln",
+        "snapshot-id": "eln-s390x-appstream",
+        "storage": "public"
+}

--- a/repo/eln-s390x-baseos.json
+++ b/repo/eln-s390x-baseos.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/BaseOS/s390x/os/",
+        "platform-id": "eln",
+        "snapshot-id": "eln-s390x-baseos",
+        "storage": "public"
+}

--- a/repo/eln-s390x-crb.json
+++ b/repo/eln-s390x-crb.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/CRB/s390x/os/",
+        "platform-id": "eln",
+        "snapshot-id": "eln-s390x-crb",
+        "storage": "public"
+}

--- a/repo/eln-x86_64-appstream.json
+++ b/repo/eln-x86_64-appstream.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/AppStream/x86_64/os/",
+        "platform-id": "eln",
+        "snapshot-id": "eln-x86_64-appstream",
+        "storage": "public"
+}

--- a/repo/eln-x86_64-baseos.json
+++ b/repo/eln-x86_64-baseos.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/BaseOS/x86_64/os/",
+        "platform-id": "eln",
+        "snapshot-id": "eln-x86_64-baseos",
+        "storage": "public"
+}

--- a/repo/eln-x86_64-crb.json
+++ b/repo/eln-x86_64-crb.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://odcs.fedoraproject.org/composes/production/latest-Fedora-ELN/compose/CRB/x86_64/os/",
+        "platform-id": "eln",
+        "snapshot-id": "eln-x86_64-crb",
+        "storage": "public"
+}


### PR DESCRIPTION
Fedora ELN is basically a rolling, version-less distribution(1).

Thus, I had to modify gen-all-repos.py to work even if the release isn't there.

gen-repos.py got a new generator just for ELN. I was thinking whether I can reuse one of the others, but since ELN is so straightforward, I decided to just create a very tiny specialized one.

(1) /etc/os-release currently specifies VERSION_ID as 40, but platform is just eln all the time. RPM's %dist macro is versioned, but this version is arbitrary because it's bumped every time a mass-rebuild is needed, see: https://fedoraproject.org/wiki/Changes/ELN_Buildroot_and_Compose#Detailed_Description

Thus, I do believe that ELN can be treated as a version-less distribution.