### PR TITLE
src/ctl: add command to build snapshots cache

### DIFF
--- a/src/ctl/cli.py
+++ b/src/ctl/cli.py
@@ -12,7 +12,7 @@ import os
 import sys
 import uuid
 
-from . import index, pull, push
+from . import index, pull, push, enumerate_cache
 
 
 class CliIndex:
@@ -76,6 +76,19 @@ class CliPush:
 
         return 0
 
+class CliEnumerateCache:
+    """EnumerateCache command"""
+
+    def __init__(self, ctx):
+        self._ctx = ctx
+
+    def run(self):
+        """Run EnumerateCache command"""
+
+        with enumerate_cache.EnumerateCache() as cmd:
+            cmd.build()
+
+        return 0
 
 class Cli(contextlib.AbstractContextManager):
     """RPMrepo Command Line Interface"""
@@ -216,6 +229,8 @@ class Cli(contextlib.AbstractContextManager):
             ret = CliPull(self).run()
         elif self.args.cmd == "push":
             ret = CliPush(self).run()
+        elif self.args.cmd == "enumerate-cache":
+            ret = CliEnumerateCache(self).run()
         else:
             raise RuntimeError("Command mismatch")
 

--- a/src/ctl/enumerate_cache.py
+++ b/src/ctl/enumerate_cache.py
@@ -1,0 +1,48 @@
+"""rpmrepo - Create RPM Repository Enumerate Cache
+
+This module enumerates all the thread indices to generate a list of
+snapshots, which it then stores under data/thread/meta/cache.json.
+
+"""
+
+# pylint: disable=duplicate-code,invalid-name,too-few-public-methods
+
+import contextlib
+import json
+
+import boto3
+
+class EnumerateCache(contextlib.AbstractContextManager):
+    """Create a cache of all the thread indices"""
+
+    def __init__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        pass
+
+    def build(self):
+        """Build the enumerate cache"""
+
+        s3c = boto3.client("s3")
+
+        results = []
+        paginator = s3c.get_paginator("list_objects_v2")
+        pages = paginator.paginate(
+            Bucket="rpmrepo-storage",
+            Prefix="data/thread/",
+            PaginationConfig={'PageSize': 16384},
+        )
+        for page in pages:
+            for entry in page.get("Contents", []):
+                # get everything past the last slash
+                key = entry.get("Key").rsplit("/", 1)[1]
+                if len(key) > 0:
+                    results.append(key)
+        results.sort()
+
+        s3c.put_object(
+            Bucket="rpmrepo-storage",
+            Key="data/thread/meta/cache.json",
+            Body=json.dumps(results, indent="  ")
+        )


### PR DESCRIPTION
Enumerates all thread indices and stores it under `data/thread/meta/cache.json`

---

We can then add support for this to https://github.com/osbuild/containers/blob/main/src/scripts/rpmrepo-snapshot.sh, and trigger this as a batch job in the scheduled-snapshots workflow.