### PR TITLE
src: enumerate cache

### DIFF
--- a/src/ctl/cli.py
+++ b/src/ctl/cli.py
@@ -183,6 +183,16 @@ class Cli(contextlib.AbstractContextManager):
             type=str,
         )
 
+        cmd_push = cmd.add_parser(
+            "enumerate-cache",
+            add_help=True,
+            allow_abbrev=False,
+            argument_default=None,
+            description="Build the cache for enumerate",
+            help="Build the cache for enumerate",
+            prog=f"{self._parser.prog} enumerate-cache",
+        )
+
         return self._parser.parse_args(self._argv[1:])
 
     def _verify_args(self):

--- a/src/gateway/lambda_function.py
+++ b/src/gateway/lambda_function.py
@@ -227,6 +227,14 @@ def _run_enumerate(arguments):
         ),
     )
 
+    # Serve the data from the enumerate cache if present
+    try:
+        obj = s3c.get_object(Bucket="rpmrepo-storage", Key="data/thread/meta/cache.json")
+        return _success(json.loads(obj['Body'].read()))
+    except botocore.exceptions.ClientError as e:
+        if not e.response['Error']['Code'] == "NoSuchKey":
+            return _error(500)
+
     prefix = "data/thread/"
     if "thread" in arguments:
         prefix = prefix + arguments["thread"] + "/"


### PR DESCRIPTION
Forgot to add the command to the arg parser, and the gateway should serve the cache if it's present. If the cache is out of date and failing to generate, we can always remove it manually.