### PR TITLE
Scheduled snapshots cache

### DIFF
--- a/.github/scripts/snapshot_update_pr.sh
+++ b/.github/scripts/snapshot_update_pr.sh
@@ -10,7 +10,10 @@ pushd "$REPO" || exit 2
 
 if [ -e ./tools/check-snapshots ]; then
     echo "Checking snapshots..."
-    ./tools/check-snapshots --errors-only . || exit 1
+    CHECK_SNAPSHOT_SUCCEEDED=false
+    if ./tools/check-snapshots --errors-only .; then
+        CHECK_SNAPSHOT_SUCCEEDED=true
+    fi
 fi
 
 # Open PR with updated Schutzfile
@@ -27,8 +30,14 @@ git commit -m "schutzfile: Update snapshots to ${SUFFIX}"
 git push https://"$GITHUB_TOKEN"@github.com/schutzbot/"$REPO".git
 
 cat <<EOF > "body"
+Results of the snapshot jobs:
 Job(s) succeeded: $JOBS_SUCCEEDED
 Job(s) failed: $JOBS_FAILED
+
+If these are false, rebuild the enumerate cache manually:
+Enumerate cache job succeeded: $ENUMERATE_CACHE_SUCCEEDED
+Check snapshot succeeded: $CHECK_SNAPSHOT_SUCCEEDED
+
 Workflow run: https://github.com/osbuild/rpmrepo/actions/runs/$WORKFLOW_RUN
 EOF
 

--- a/.github/workflows/scheduled-snapshots.yml
+++ b/.github/workflows/scheduled-snapshots.yml
@@ -31,7 +31,7 @@ jobs:
       id: generate_suffix
       run: echo "suffix=$(date '+%Y%m%d')" >>$GITHUB_OUTPUT
 
-    - name: Submit array job
+    - name: Submit snapshot array job
       id: submit_job
       run: |
         echo size ${{ steps.count_jobs.outputs.size }} sha ${GITHUB_SHA}
@@ -47,7 +47,7 @@ jobs:
         echo "job_id=$(jq -r .jobId out.json)" >>$GITHUB_OUTPUT
         echo "job_name=$(jq -r .jobName out.json)" >>$GITHUB_OUTPUT
 
-    - name: Wait for jobs to start
+    - name: Wait for snapshot jobs to start
       id: wait_for_jobs_start
       run: |
         while true; do
@@ -63,7 +63,7 @@ jobs:
           sleep 30s
         done
 
-    - name: Wait for jobs to finish
+    - name: Wait for snapshot jobs to finish
       id: wait_for_jobs
       run: |
         while true; do
@@ -96,6 +96,37 @@ jobs:
         echo "succeeded=$SUCCEEDED" >>$GITHUB_OUTPUT
         echo "failed=$(jq '.jobSummaryList | length' failed.json)" >>$GITHUB_OUTPUT
 
+    - name: Submit enumerate-cache job
+      id: submit_cache_job
+      run: |
+        aws batch submit-job \
+          --job-name "enumerate-cache-runner" \
+          --job-definition "rpmrepo-batch-enumerate-cache-staging" \
+          --job-queue "rpmrepo-batch-staging" \
+          --timeout "attemptDurationSeconds=600"
+          > out.json
+        echo "enumerate_cache_job_id=$(jq -r .jobId out.json)" >>$GITHUB_OUTPUT
+        echo "enumerate_cache_job_name=$(jq -r .jobName out.json)" >>$GITHUB_OUTPUT
+
+    - name: Wait for enumerate cache job to finish
+      id: wait_for_cache_job
+      run: |
+        while true; do
+          STATUS=$(aws batch describe-jobs \
+            --jobs ${{ steps.submit_cache_job.outputs.enumerate_cache_job_id}} \
+            | jq -r .jobs[0].status)
+          if [ $STATUS = "FAILED" ]; then
+            echo "enumerate_cache_succeeded=false" >>$GITHUB_OUTPUT
+            break
+          fi
+          if [ $STATUS = "SUCCEEDED" ]; then
+            echo "enumerate_cache_succeeded=true" >>$GITHUB_OUTPUT
+            break
+          fi
+          echo "Waiting on cache job (status: $STATUS)"
+          sleep 10s
+        done
+
     - name: Clone osbuild-composer repository
       uses: actions/checkout@v4
       with:
@@ -110,6 +141,7 @@ jobs:
         JOBS_SUCCEEDED: ${{ steps.wait_for_jobs-outputs.succeeded }}
         JOBS_FAILED: ${{ steps.wait_for_jobs.outputs.failed }}
         WORKFLOW_RUN: ${{ github.run_id }}
+        ENUMERATE_CACHE_SUCCEEDED: ${{steps.wait_for_cache_job.outputs.enumerate_cache_succeeded}}
         REPO: "osbuild-composer"
       run: .github/scripts/snapshot_update_pr.sh
 
@@ -127,6 +159,7 @@ jobs:
         JOBS_SUCCEEDED: ${{ steps.wait_for_jobs-outputs.succeeded }}
         JOBS_FAILED: ${{ steps.wait_for_jobs.outputs.failed }}
         WORKFLOW_RUN: ${{ github.run_id }}
+        ENUMERATE_CACHE_SUCCEEDED: ${{steps.wait_for_cache_job.outputs.enumerate_cache_succeeded}}
         REPO: "osbuild"
       run: .github/scripts/snapshot_update_pr.sh
 
@@ -144,6 +177,7 @@ jobs:
         JOBS_SUCCEEDED: ${{ steps.wait_for_jobs-outputs.succeeded }}
         JOBS_FAILED: ${{ steps.wait_for_jobs.outputs.failed }}
         WORKFLOW_RUN: ${{ github.run_id }}
+        ENUMERATE_CACHE_SUCCEEDED: ${{steps.wait_for_cache_job.outputs.enumerate_cache_succeeded}}
         REPO: "cloud-image-val"
       run: .github/scripts/snapshot_update_pr.sh
 
@@ -161,5 +195,6 @@ jobs:
         JOBS_SUCCEEDED: ${{ steps.wait_for_jobs-outputs.succeeded }}
         JOBS_FAILED: ${{ steps.wait_for_jobs.outputs.failed }}
         WORKFLOW_RUN: ${{ github.run_id }}
+        ENUMERATE_CACHE_SUCCEEDED: ${{steps.wait_for_cache_job.outputs.enumerate_cache_succeeded}}
         REPO: "images"
       run: .github/scripts/snapshot_update_pr.sh

--- a/.github/workflows/scheduled-snapshots.yml
+++ b/.github/workflows/scheduled-snapshots.yml
@@ -138,7 +138,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.SCHUTZBOT_GH_TOKEN }}
         SUFFIX: ${{ steps.generate_suffix.outputs.suffix }}
-        JOBS_SUCCEEDED: ${{ steps.wait_for_jobs-outputs.succeeded }}
+        JOBS_SUCCEEDED: ${{ steps.wait_for_jobs.outputs.succeeded }}
         JOBS_FAILED: ${{ steps.wait_for_jobs.outputs.failed }}
         WORKFLOW_RUN: ${{ github.run_id }}
         ENUMERATE_CACHE_SUCCEEDED: ${{steps.wait_for_cache_job.outputs.enumerate_cache_succeeded}}
@@ -156,7 +156,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.SCHUTZBOT_GH_TOKEN }}
         SUFFIX: ${{ steps.generate_suffix.outputs.suffix }}
-        JOBS_SUCCEEDED: ${{ steps.wait_for_jobs-outputs.succeeded }}
+        JOBS_SUCCEEDED: ${{ steps.wait_for_jobs.outputs.succeeded }}
         JOBS_FAILED: ${{ steps.wait_for_jobs.outputs.failed }}
         WORKFLOW_RUN: ${{ github.run_id }}
         ENUMERATE_CACHE_SUCCEEDED: ${{steps.wait_for_cache_job.outputs.enumerate_cache_succeeded}}
@@ -174,7 +174,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.SCHUTZBOT_GH_TOKEN }}
         SUFFIX: ${{ steps.generate_suffix.outputs.suffix }}
-        JOBS_SUCCEEDED: ${{ steps.wait_for_jobs-outputs.succeeded }}
+        JOBS_SUCCEEDED: ${{ steps.wait_for_jobs.outputs.succeeded }}
         JOBS_FAILED: ${{ steps.wait_for_jobs.outputs.failed }}
         WORKFLOW_RUN: ${{ github.run_id }}
         ENUMERATE_CACHE_SUCCEEDED: ${{steps.wait_for_cache_job.outputs.enumerate_cache_succeeded}}
@@ -192,7 +192,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.SCHUTZBOT_GH_TOKEN }}
         SUFFIX: ${{ steps.generate_suffix.outputs.suffix }}
-        JOBS_SUCCEEDED: ${{ steps.wait_for_jobs-outputs.succeeded }}
+        JOBS_SUCCEEDED: ${{ steps.wait_for_jobs.outputs.succeeded }}
         JOBS_FAILED: ${{ steps.wait_for_jobs.outputs.failed }}
         WORKFLOW_RUN: ${{ github.run_id }}
         ENUMERATE_CACHE_SUCCEEDED: ${{steps.wait_for_cache_job.outputs.enumerate_cache_succeeded}}


### PR DESCRIPTION


The PRs will now always be opened regardless of the check-snapshot, but with the following body:
```
Results of the snapshot jobs:
Job(s) succeeded: $JOBS_SUCCEEDED
Job(s) failed: $JOBS_FAILED

If these are false, rebuild the enumerate cache manually:
Enumerate cache job succeeded: $ENUMERATE_CACHE_SUCCEEDED
Check snapshot succeeded: $CHECK_SNAPSHOT_SUCCEEDED

Workflow run: https://github.com/osbuild/rpmrepo/actions/runs/$WORKFLOW_RUN
```

This way the snapshots aren't thrown away, we can still just close the PR, and we can rebuild the cache manually if that's the only part that went wrong.