### PR TITLE
github/scheduled-snapshots: fix output redirect

### DIFF
--- a/.github/workflows/scheduled-snapshots.yml
+++ b/.github/workflows/scheduled-snapshots.yml
@@ -103,8 +103,7 @@ jobs:
           --job-name "enumerate-cache-runner" \
           --job-definition "rpmrepo-batch-enumerate-cache-staging" \
           --job-queue "rpmrepo-batch-staging" \
-          --timeout "attemptDurationSeconds=600"
-          > out.json
+          --timeout "attemptDurationSeconds=600" > out.json
         echo "enumerate_cache_job_id=$(jq -r .jobId out.json)" >>$GITHUB_OUTPUT
         echo "enumerate_cache_job_name=$(jq -r .jobName out.json)" >>$GITHUB_OUTPUT
 


### PR DESCRIPTION
The '> out' was on a separate line from the command without a '\' on the previous line, so out.json was always empty.

See https://github.com/osbuild/rpmrepo/actions/runs/10397209645/job/28792528624 for failure.
Currently running a snapshot job on this branch: https://github.com/osbuild/rpmrepo/actions/runs/10452286390/job/28940408904

EDIT: IT WORKS!