### PR TITLE
Update internal RH repo URLs and don't snapshot EOL F39

### DIFF
--- a/repo-definitions.yaml
+++ b/repo-definitions.yaml
@@ -257,15 +257,6 @@ rhel:
 
 fedora:
 # stable releases
-- release: '39'
-  stream: releases
-  singleton: '20231109'
-  repo_name:
-    - Everything
-- release: '39'
-  stream: updates
-  repo_name:
-    - Everything
 - release: '40'
   stream: releases
   singleton: '20240514'

--- a/repo-definitions.yaml
+++ b/repo-definitions.yaml
@@ -19,28 +19,28 @@ rhel:
 - release: '7.9'
   arch:
     - x86_64
-  base_url: http://download.eng.bos.redhat.com/rhel-7/rel-eng/EXTRAS-7/latest-EXTRAS-7.9-RHEL-7/compose/Server/x86_64/os/
+  base_url: http://download.devel.redhat.com/rhel-7/rel-eng/EXTRAS-7/latest-EXTRAS-7.9-RHEL-7/compose/Server/x86_64/os/
   snapshot_id_suffix: server-extras-r7.9
 - release: '7.9'
   singleton: '20230809'
   arch:
     - x86_64
-  base_url: http://download.eng.bos.redhat.com/rhel-7/rel-eng/dotNET-1.1-RHEL-7-20161128.0/compose/Server/x86_64/os/
+  base_url: http://download.devel.redhat.com/rhel-7/rel-eng/dotNET-1.1-RHEL-7-20161128.0/compose/Server/x86_64/os/
   snapshot_id_suffix: server-dotnet-r1.1
 - release: '7.9'
   arch:
     - x86_64
-  base_url: http://download.eng.bos.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel7/
+  base_url: http://download.devel.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel7/
   snapshot_id_suffix: rhui-azure
 - release: '7.9'
   arch:
     - x86_64
-  base_url: http://download.eng.bos.redhat.com/rhel-7/rel-eng/RHUI/latest-RHUI-Client-3-RHEL-7/compose/RHUI/x86_64/os/
+  base_url: http://download.devel.redhat.com/rhel-7/rel-eng/RHUI/latest-RHUI-Client-3-RHEL-7/compose/RHUI/x86_64/os/
   snapshot_id_suffix: rhui-3
 - release: '7.9'
   arch:
     - x86_64
-  base_url: http://download.eng.bos.redhat.com/released/jboss/eap7/latest-released/JBEAP-7-RHEL-7/Server/x86_64/os/
+  base_url: http://download.devel.redhat.com/released/jboss/eap7/latest-released/JBEAP-7-RHEL-7/Server/x86_64/os/
   snapshot_id_suffix: jbeap7
 - release: '7.9'
   arch:
@@ -50,7 +50,7 @@ rhel:
 - release: '7.9'
   arch:
     - x86_64
-  base_url: http://download.lab.bos.redhat.com/rhel-7/devel/candidate-trees/RHEL-7/latest-RHEL-7.9/compose/Server/x86_64/os/
+  base_url: http://download.devel.redhat.com/rhel-7/devel/candidate-trees/RHEL-7/latest-RHEL-7.9/compose/Server/x86_64/os/
   snapshot_id_suffix: server-updates-7.9
 # Snapshots of RHEL-7.9 repos
 - release: '7.9'
@@ -75,22 +75,22 @@ rhel:
 - release: '8.0'
   arch:
     - x86_64
-  base_url: http://download.eng.bos.redhat.com/rel-eng/rhel-8/RHUI/latest-RHUI-Client-3-RHEL-8/compose/RHUI/x86_64/os/
+  base_url: http://download.devel.redhat.com/rel-eng/rhel-8/RHUI/latest-RHUI-Client-3-RHEL-8/compose/RHUI/x86_64/os/
   snapshot_id_suffix: rhui-3
 - release: '8.0'
   arch:
     - aarch64
-  base_url: http://download.eng.bos.redhat.com/rel-eng/rhel-8/RHUI/latest-RHUI-Client-3-RHEL-8/compose/RHUI/aarch64/os/
+  base_url: http://download.devel.redhat.com/rel-eng/rhel-8/RHUI/latest-RHUI-Client-3-RHEL-8/compose/RHUI/aarch64/os/
   snapshot_id_suffix: rhui-3
 - release: '8.0'
   arch:
     - x86_64
-  base_url: http://download.eng.bos.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel8/
+  base_url: http://download.devel.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel8/
   snapshot_id_suffix: rhui-azure
 - release: '8.0'
   arch:
     - x86_64
-  base_url: http://download.eng.bos.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel8-sap-ha/
+  base_url: http://download.devel.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel8-sap-ha/
   snapshot_id_suffix: sap-rhui-azure
 - release: '8.0'
   arch:
@@ -100,7 +100,7 @@ rhel:
 - release: '8.0'
   arch:
     - x86_64
-  base_url: http://download.eng.bos.redhat.com/released/jboss/eap7/latest-released/JBEAP-7-RHEL-8/Server/x86_64/os/
+  base_url: http://download.devel.redhat.com/released/jboss/eap7/latest-released/JBEAP-7-RHEL-8/Server/x86_64/os/
   snapshot_id_suffix: jbeap7
 - release: '8.0'
   arch:
@@ -207,27 +207,27 @@ rhel:
 - release: '9.0'
   arch:
     - x86_64
-  base_url: http://download.eng.bos.redhat.com/rhel-9/rel-eng/RHUI/latest-RHUI-Client-4-RHEL-9/compose/RHUI/x86_64/os/
+  base_url: http://download.devel.redhat.com/rhel-9/rel-eng/RHUI/latest-RHUI-Client-4-RHEL-9/compose/RHUI/x86_64/os/
   snapshot_id_suffix: rhui-4
 - release: '9.0'
   arch:
     - aarch64
-  base_url: http://download.eng.bos.redhat.com/rhel-9/rel-eng/RHUI/latest-RHUI-Client-4-RHEL-9/compose/RHUI/aarch64/os/
+  base_url: http://download.devel.redhat.com/rhel-9/rel-eng/RHUI/latest-RHUI-Client-4-RHEL-9/compose/RHUI/aarch64/os/
   snapshot_id_suffix: rhui-4
 - release: '9.0'
   arch:
     - x86_64
-  base_url: http://download.eng.bos.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel9/
+  base_url: http://download.devel.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel9/
   snapshot_id_suffix: rhui-azure
 - release: '9.0'
   arch:
     - x86_64
-  base_url: http://download.eng.bos.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel9-sap-ha/
+  base_url: http://download.devel.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel9-sap-ha/
   snapshot_id_suffix: sap-rhui-azure
 - release: '9.0'
   arch:
     - x86_64
-  base_url: http://download.eng.bos.redhat.com/released/jboss/eap7/latest-released/JBEAP-7-RHEL-9/Server/x86_64/os/
+  base_url: http://download.devel.redhat.com/released/jboss/eap7/latest-released/JBEAP-7-RHEL-9/Server/x86_64/os/
   snapshot_id_suffix: jbeap7
 - release: '9.0'
   arch:

--- a/repo/el7-x86_64-jbeap7.json
+++ b/repo/el7-x86_64-jbeap7.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download.eng.bos.redhat.com/released/jboss/eap7/latest-released/JBEAP-7-RHEL-7/Server/x86_64/os/",
+        "base-url": "http://download.devel.redhat.com/released/jboss/eap7/latest-released/JBEAP-7-RHEL-7/Server/x86_64/os/",
         "platform-id": "el7",
         "snapshot-id": "el7-x86_64-jbeap7",
         "storage": "rhvpn"

--- a/repo/el7-x86_64-rhui-3.json
+++ b/repo/el7-x86_64-rhui-3.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download.eng.bos.redhat.com/rhel-7/rel-eng/RHUI/latest-RHUI-Client-3-RHEL-7/compose/RHUI/x86_64/os/",
+        "base-url": "http://download.devel.redhat.com/rhel-7/rel-eng/RHUI/latest-RHUI-Client-3-RHEL-7/compose/RHUI/x86_64/os/",
         "platform-id": "el7",
         "snapshot-id": "el7-x86_64-rhui-3",
         "storage": "rhvpn"

--- a/repo/el7-x86_64-rhui-azure.json
+++ b/repo/el7-x86_64-rhui-azure.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download.eng.bos.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel7/",
+        "base-url": "http://download.devel.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel7/",
         "platform-id": "el7",
         "snapshot-id": "el7-x86_64-rhui-azure",
         "storage": "rhvpn"

--- a/repo/el7-x86_64-server-dotnet-r1.1.json
+++ b/repo/el7-x86_64-server-dotnet-r1.1.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download.eng.bos.redhat.com/rhel-7/rel-eng/dotNET-1.1-RHEL-7-20161128.0/compose/Server/x86_64/os/",
+        "base-url": "http://download.devel.redhat.com/rhel-7/rel-eng/dotNET-1.1-RHEL-7-20161128.0/compose/Server/x86_64/os/",
         "platform-id": "el7",
         "singleton": "20230809",
         "snapshot-id": "el7-x86_64-server-dotnet-r1.1",

--- a/repo/el7-x86_64-server-extras-r7.9.json
+++ b/repo/el7-x86_64-server-extras-r7.9.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download.eng.bos.redhat.com/rhel-7/rel-eng/EXTRAS-7/latest-EXTRAS-7.9-RHEL-7/compose/Server/x86_64/os/",
+        "base-url": "http://download.devel.redhat.com/rhel-7/rel-eng/EXTRAS-7/latest-EXTRAS-7.9-RHEL-7/compose/Server/x86_64/os/",
         "platform-id": "el7",
         "snapshot-id": "el7-x86_64-server-extras-r7.9",
         "storage": "rhvpn"

--- a/repo/el7-x86_64-server-updates-7.9.json
+++ b/repo/el7-x86_64-server-updates-7.9.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download.lab.bos.redhat.com/rhel-7/devel/candidate-trees/RHEL-7/latest-RHEL-7.9/compose/Server/x86_64/os/",
+        "base-url": "http://download.devel.redhat.com/rhel-7/devel/candidate-trees/RHEL-7/latest-RHEL-7.9/compose/Server/x86_64/os/",
         "platform-id": "el7",
         "snapshot-id": "el7-x86_64-server-updates-7.9",
         "storage": "rhvpn"

--- a/repo/el8-aarch64-rhui-3.json
+++ b/repo/el8-aarch64-rhui-3.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download.eng.bos.redhat.com/rel-eng/rhel-8/RHUI/latest-RHUI-Client-3-RHEL-8/compose/RHUI/aarch64/os/",
+        "base-url": "http://download.devel.redhat.com/rel-eng/rhel-8/RHUI/latest-RHUI-Client-3-RHEL-8/compose/RHUI/aarch64/os/",
         "platform-id": "el8",
         "snapshot-id": "el8-aarch64-rhui-3",
         "storage": "rhvpn"

--- a/repo/el8-x86_64-jbeap7.json
+++ b/repo/el8-x86_64-jbeap7.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download.eng.bos.redhat.com/released/jboss/eap7/latest-released/JBEAP-7-RHEL-8/Server/x86_64/os/",
+        "base-url": "http://download.devel.redhat.com/released/jboss/eap7/latest-released/JBEAP-7-RHEL-8/Server/x86_64/os/",
         "platform-id": "el8",
         "snapshot-id": "el8-x86_64-jbeap7",
         "storage": "rhvpn"

--- a/repo/el8-x86_64-rhui-3.json
+++ b/repo/el8-x86_64-rhui-3.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download.eng.bos.redhat.com/rel-eng/rhel-8/RHUI/latest-RHUI-Client-3-RHEL-8/compose/RHUI/x86_64/os/",
+        "base-url": "http://download.devel.redhat.com/rel-eng/rhel-8/RHUI/latest-RHUI-Client-3-RHEL-8/compose/RHUI/x86_64/os/",
         "platform-id": "el8",
         "snapshot-id": "el8-x86_64-rhui-3",
         "storage": "rhvpn"

--- a/repo/el8-x86_64-rhui-azure.json
+++ b/repo/el8-x86_64-rhui-azure.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download.eng.bos.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel8/",
+        "base-url": "http://download.devel.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel8/",
         "platform-id": "el8",
         "snapshot-id": "el8-x86_64-rhui-azure",
         "storage": "rhvpn"

--- a/repo/el8-x86_64-sap-rhui-azure.json
+++ b/repo/el8-x86_64-sap-rhui-azure.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download.eng.bos.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel8-sap-ha/",
+        "base-url": "http://download.devel.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel8-sap-ha/",
         "platform-id": "el8",
         "snapshot-id": "el8-x86_64-sap-rhui-azure",
         "storage": "rhvpn"

--- a/repo/el9-aarch64-rhui-4.json
+++ b/repo/el9-aarch64-rhui-4.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download.eng.bos.redhat.com/rhel-9/rel-eng/RHUI/latest-RHUI-Client-4-RHEL-9/compose/RHUI/aarch64/os/",
+        "base-url": "http://download.devel.redhat.com/rhel-9/rel-eng/RHUI/latest-RHUI-Client-4-RHEL-9/compose/RHUI/aarch64/os/",
         "platform-id": "el9",
         "snapshot-id": "el9-aarch64-rhui-4",
         "storage": "rhvpn"

--- a/repo/el9-x86_64-jbeap7.json
+++ b/repo/el9-x86_64-jbeap7.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download.eng.bos.redhat.com/released/jboss/eap7/latest-released/JBEAP-7-RHEL-9/Server/x86_64/os/",
+        "base-url": "http://download.devel.redhat.com/released/jboss/eap7/latest-released/JBEAP-7-RHEL-9/Server/x86_64/os/",
         "platform-id": "el9",
         "snapshot-id": "el9-x86_64-jbeap7",
         "storage": "rhvpn"

--- a/repo/el9-x86_64-rhui-4.json
+++ b/repo/el9-x86_64-rhui-4.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download.eng.bos.redhat.com/rhel-9/rel-eng/RHUI/latest-RHUI-Client-4-RHEL-9/compose/RHUI/x86_64/os/",
+        "base-url": "http://download.devel.redhat.com/rhel-9/rel-eng/RHUI/latest-RHUI-Client-4-RHEL-9/compose/RHUI/x86_64/os/",
         "platform-id": "el9",
         "snapshot-id": "el9-x86_64-rhui-4",
         "storage": "rhvpn"

--- a/repo/el9-x86_64-rhui-azure.json
+++ b/repo/el9-x86_64-rhui-azure.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download.eng.bos.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel9/",
+        "base-url": "http://download.devel.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel9/",
         "platform-id": "el9",
         "snapshot-id": "el9-x86_64-rhui-azure",
         "storage": "rhvpn"

--- a/repo/el9-x86_64-sap-rhui-azure.json
+++ b/repo/el9-x86_64-sap-rhui-azure.json
@@ -1,5 +1,5 @@
 {
-        "base-url": "http://download.eng.bos.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel9-sap-ha/",
+        "base-url": "http://download.devel.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel9-sap-ha/",
         "platform-id": "el9",
         "snapshot-id": "el9-x86_64-sap-rhui-azure",
         "storage": "rhvpn"

--- a/repo/f39-aarch64-fedora.json
+++ b/repo/f39-aarch64-fedora.json
@@ -1,7 +1,0 @@
-{
-        "base-url": "https://dl01.fedoraproject.org/pub/fedora/linux/releases/39/Everything/aarch64/os/",
-        "platform-id": "f39",
-        "singleton": "20231109",
-        "snapshot-id": "f39-aarch64-fedora",
-        "storage": "public"
-}

--- a/repo/f39-aarch64-updates-released.json
+++ b/repo/f39-aarch64-updates-released.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "https://dl01.fedoraproject.org/pub/fedora/linux/updates/39/Everything/aarch64/",
-        "platform-id": "f39",
-        "snapshot-id": "f39-aarch64-updates-released",
-        "storage": "public"
-}

--- a/repo/f39-ppc64le-fedora.json
+++ b/repo/f39-ppc64le-fedora.json
@@ -1,7 +1,0 @@
-{
-        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/releases/39/Everything/ppc64le/os/",
-        "platform-id": "f39",
-        "singleton": "20231109",
-        "snapshot-id": "f39-ppc64le-fedora",
-        "storage": "public"
-}

--- a/repo/f39-ppc64le-updates-released.json
+++ b/repo/f39-ppc64le-updates-released.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/updates/39/Everything/ppc64le/",
-        "platform-id": "f39",
-        "snapshot-id": "f39-ppc64le-updates-released",
-        "storage": "public"
-}

--- a/repo/f39-s390x-fedora.json
+++ b/repo/f39-s390x-fedora.json
@@ -1,7 +1,0 @@
-{
-        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/releases/39/Everything/s390x/os/",
-        "platform-id": "f39",
-        "singleton": "20231109",
-        "snapshot-id": "f39-s390x-fedora",
-        "storage": "public"
-}

--- a/repo/f39-s390x-updates-released.json
+++ b/repo/f39-s390x-updates-released.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/updates/39/Everything/s390x/",
-        "platform-id": "f39",
-        "snapshot-id": "f39-s390x-updates-released",
-        "storage": "public"
-}

--- a/repo/f39-x86_64-fedora.json
+++ b/repo/f39-x86_64-fedora.json
@@ -1,7 +1,0 @@
-{
-        "base-url": "https://dl01.fedoraproject.org/pub/fedora/linux/releases/39/Everything/x86_64/os/",
-        "platform-id": "f39",
-        "singleton": "20231109",
-        "snapshot-id": "f39-x86_64-fedora",
-        "storage": "public"
-}

--- a/repo/f39-x86_64-updates-released.json
+++ b/repo/f39-x86_64-updates-released.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "https://dl01.fedoraproject.org/pub/fedora/linux/updates/39/Everything/x86_64/",
-        "platform-id": "f39",
-        "snapshot-id": "f39-x86_64-updates-released",
-        "storage": "public"
-}


### PR DESCRIPTION
- Replace download.*.bos.redhat.com -> download.devel.redhat.com
- Don't snapshot EOL Fedora 39