### PR TITLE
Rework schutzfile updates

### DIFF
--- a/.github/scripts/test_update_schutzfile.py
+++ b/.github/scripts/test_update_schutzfile.py
@@ -1,0 +1,427 @@
+#!/usr/bin/python3
+
+"""update_schutzfile tests"""
+
+
+import json
+import os
+import pytest
+
+import update_schutzfile
+
+# pylint: disable=missing-function-docstring
+
+SCHUTZFILE_INPUT_TEST_DISTRO = {
+    "test_distro": {
+        "repos": [
+            {
+                "file": "bogus",
+                "test_arch": [
+                    {
+                        "baseurl": "http://realurl.org/realrepo-12345678",
+                    },
+                    {
+                        "baseurl": "http://realurl.org/realotherrepo-12345678",
+                    },
+                ],
+            },
+        ],
+    },
+}
+
+
+SCHUTZFILE_INPUT = [
+    # base case
+    (
+        SCHUTZFILE_INPUT_TEST_DISTRO,
+        {
+            "test_distro": {
+                "repos": [
+                    {
+                        "file": "bogus",
+                        "test_arch": [
+                            {
+                                "baseurl": "http://realurl.org/realrepo-87654321",
+                            },
+                            {
+                                "baseurl": "http://realurl.org/realotherrepo-87654321",
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+        [],
+        [
+            "realrepo-12345678",
+            "realotherrepo-12345678",
+            "realrepo-87654321",
+            "realotherrepo-87654321",
+        ],
+    ),
+    # no updates if one snapshot in arch is missing
+    (
+        SCHUTZFILE_INPUT_TEST_DISTRO,
+        {
+            "test_distro": {
+                "repos": [
+                    {
+                        "file": "bogus",
+                        "test_arch": [
+                            {
+                                "baseurl": "http://realurl.org/realrepo-12345678",
+                            },
+                            {
+                                "baseurl": "http://realurl.org/realotherrepo-12345678",
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+        [],
+        [
+            "realrepo-12345678",
+            "realotherrepo-12345678",
+            "realrepo-87654321",
+        ],
+    ),
+    # old snapshots missing is fine
+    (
+        SCHUTZFILE_INPUT_TEST_DISTRO,
+        {
+            "test_distro": {
+                "repos": [
+                    {
+                        "file": "bogus",
+                        "test_arch": [
+                            {
+                                "baseurl": "http://realurl.org/realrepo-87654321",
+                            },
+                            {
+                                "baseurl": "http://realurl.org/realotherrepo-87654321",
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+        [],
+        [
+            "realrepo-12345678",
+            "realrepo-87654321",
+            "realotherrepo-87654321",
+        ],
+    ),
+    # non-snapshot repos are ignored
+    (
+        {
+            "test_distro": {
+                "repos": [
+                    {
+                        "file": "bogus",
+                        "test_arch": [
+                            {
+                                "baseurl": "http://realurl.org/realrepo-nosnapshot",
+                            },
+                            {
+                                "baseurl": "http://realurl.org/realotherrepo-12345678",
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+        {
+            "test_distro": {
+                "repos": [
+                    {
+                        "file": "bogus",
+                        "test_arch": [
+                            {
+                                "baseurl": "http://realurl.org/realrepo-nosnapshot",
+                            },
+                            {
+                                "baseurl": "http://realurl.org/realotherrepo-87654321",
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+        [],
+        [
+            "realotherrepo-12345678",
+            "realotherrepo-87654321",
+        ],
+    ),
+    # no updates just for singletons
+    (
+        SCHUTZFILE_INPUT_TEST_DISTRO,
+        {
+            "test_distro": {
+                "repos": [
+                    {
+                        "file": "bogus",
+                        "test_arch": [
+                            {
+                                "baseurl": "http://realurl.org/realrepo-12345678",
+                            },
+                            {
+                                "baseurl": "http://realurl.org/realotherrepo-87654321",
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+        ["realrepo-12345678"],
+        [
+            "realrepo-12345678",
+            "realotherrepo-12345678",
+            "realrepo-87654321",
+            "realotherrepo-87654321",
+        ],
+    ),
+    # no updates in case of singleton and missing snapshots
+    (
+        {
+            "test_distro": {
+                "repos": [
+                    {
+                        "file": "bogus",
+                        "test_arch": [
+                            {
+                                "baseurl": "http://realurl.org/realrepo-12345678",
+                            },
+                            {
+                                "baseurl": "http://realurl.org/realotherrepo-12345678",
+                            },
+                            {
+                                "baseurl": "http://realurl.org/realothersquaredrepo-12345678",
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+        {
+            "test_distro": {
+                "repos": [
+                    {
+                        "file": "bogus",
+                        "test_arch": [
+                            {
+                                "baseurl": "http://realurl.org/realrepo-12345678",
+                            },
+                            {
+                                "baseurl": "http://realurl.org/realotherrepo-12345678",
+                            },
+                            {
+                                "baseurl": "http://realurl.org/realothersquaredrepo-12345678",
+                            },
+                        ],
+                    },
+                ],
+            },
+        },
+        ["realrepo-12345678"],
+        [
+            "realrepo-12345678",
+            "realotherrepo-12345678",
+            "realothersquaredrepo-12345678",
+            "realotherrepo-87654321",
+        ],
+    ),
+]
+
+
+@pytest.mark.parametrize("input_sf,exp_sf,singletons,live_snapshots", SCHUTZFILE_INPUT)
+def test_write_schutzfile(tmp_path, input_sf, exp_sf, singletons, live_snapshots):
+    with open(os.path.join(tmp_path, "Schutzfile"), "w", encoding="utf-8") as filp:
+        json.dump(input_sf, filp, indent=2)
+
+    update_schutzfile.write_schutzfile(
+        tmp_path, False, "87654321", singletons, live_snapshots
+    )
+
+    with open(os.path.join(tmp_path, "Schutzfile"), "r", encoding="utf-8") as filp:
+        data = json.load(filp)
+    assert exp_sf == data
+
+
+REPOSITORIES_INPUT_ARCH = {
+    "test_arch": [
+        {
+            "baseurl": "http://realurl.org/realrepo-12345678",
+        },
+        {
+            "baseurl": "http://realurl.org/realotherrepo-12345678",
+        },
+    ],
+}
+
+REPOSITORIES_INPUT = [
+    # base case
+    (
+        REPOSITORIES_INPUT_ARCH,
+        {
+            "test_arch": [
+                {
+                    "baseurl": "http://realurl.org/realrepo-87654321",
+                },
+                {
+                    "baseurl": "http://realurl.org/realotherrepo-87654321",
+                },
+            ],
+        },
+        [],
+        [
+            "realrepo-12345678",
+            "realotherrepo-12345678",
+            "realrepo-87654321",
+            "realotherrepo-87654321",
+        ],
+    ),
+    # no updates for singletons
+    (
+        REPOSITORIES_INPUT_ARCH,
+        {
+            "test_arch": [
+                {
+                    "baseurl": "http://realurl.org/realrepo-12345678",
+                },
+                {
+                    "baseurl": "http://realurl.org/realotherrepo-87654321",
+                },
+            ],
+        },
+        ["realrepo-12345678"],
+        [
+            "realrepo-12345678",
+            "realotherrepo-12345678",
+            "realotherrepo-87654321",
+        ],
+    ),
+    # no updates if one snapshot in arch is missing
+    (
+        REPOSITORIES_INPUT_ARCH,
+        {
+            "test_arch": [
+                {
+                    "baseurl": "http://realurl.org/realrepo-12345678",
+                },
+                {
+                    "baseurl": "http://realurl.org/realotherrepo-12345678",
+                },
+            ],
+        },
+        [],
+        [
+            "realrepo-12345678",
+            "realotherrepo-12345678",
+            "realotherrepo-87654321",
+        ],
+    ),
+    # old snapshots missing is fine
+    (
+        REPOSITORIES_INPUT_ARCH,
+        {
+            "test_arch": [
+                {
+                    "baseurl": "http://realurl.org/realrepo-87654321",
+                },
+                {
+                    "baseurl": "http://realurl.org/realotherrepo-87654321",
+                },
+            ],
+        },
+        [],
+        [
+            "realrepo-12345678",
+            "realrepo-87654321",
+            "realotherrepo-87654321",
+        ],
+    ),
+    # non-snapshot repos are ignored
+    (
+        {
+            "test_arch": [
+                {
+                    "baseurl": "http://realurl.org/realrepo-nosnapshot",
+                },
+                {
+                    "baseurl": "http://realurl.org/realotherrepo-12345678",
+                },
+            ],
+        },
+        {
+            "test_arch": [
+                {
+                    "baseurl": "http://realurl.org/realrepo-nosnapshot",
+                },
+                {
+                    "baseurl": "http://realurl.org/realotherrepo-87654321",
+                },
+            ],
+        },
+        [],
+        [
+            "realotherrepo-12345678",
+            "realotherrepo-87654321",
+        ],
+    ),
+    # no updates in case of singleton and missing snapshots
+    (
+        {
+            "test_arch": [
+                {
+                    "baseurl": "http://realurl.org/realrepo-12345678",
+                },
+                {
+                    "baseurl": "http://realurl.org/realotherrepo-12345678",
+                },
+                {
+                    "baseurl": "http://realurl.org/realothersquaredrepo-12345678",
+                },
+            ],
+        },
+        {
+            "test_arch": [
+                {
+                    "baseurl": "http://realurl.org/realrepo-12345678",
+                },
+                {
+                    "baseurl": "http://realurl.org/realotherrepo-12345678",
+                },
+                {
+                    "baseurl": "http://realurl.org/realothersquaredrepo-12345678",
+                },
+            ],
+        },
+        ["realrepo-12345678"],
+        [
+            "realrepo-12345678",
+            "realotherrepo-12345678",
+            "realothersquaredrepo-12345678",
+            "realotherrepo-87654321",
+        ],
+    ),
+]
+
+
+@pytest.mark.parametrize("input_r,exp_r,singletons,live_snapshots", REPOSITORIES_INPUT)
+def test_write_test_repositories(tmp_path, input_r, exp_r, singletons, live_snapshots):
+    os.makedirs(os.path.join(tmp_path, "test/data/repositories"))
+    repo_path = os.path.join(tmp_path, "test/data/repositories", "repo.json")
+
+    with open(repo_path, "w", encoding="utf-8") as filp:
+        json.dump(input_r, filp, indent=2)
+
+    update_schutzfile.write_test_repositories(
+        tmp_path, False, "87654321", singletons, live_snapshots
+    )
+
+    with open(repo_path, "r", encoding="utf-8") as filp:
+        data = json.load(filp)
+    assert exp_r == data

--- a/.github/scripts/update_schutzfile.py
+++ b/.github/scripts/update_schutzfile.py
@@ -5,6 +5,148 @@ import json
 import os
 import re
 import argparse
+import urllib
+import requests
+
+def basename(url):
+    """Get basename from the path of a url"""
+    return os.path.basename(urllib.parse.urlparse(url.strip("/")).path)
+
+
+def is_snapshot(url):
+    """Check if a url is formatted as a snapshot"""
+    return re.match(".*-[0-9]{8}$", basename(url)) is not None
+
+
+def is_singleton(url, singletons):
+    """Check if a url is a singleton"""
+    return any(singleton in url for singleton in singletons)
+
+
+# pylint: disable=too-many-branches
+def write_schutzfile(repo_folder, dry_run, suffix, singletons, live_snapshots):
+    """
+    Update Schutzfile, which has the following structure:
+    {
+      "distro": {
+        "repos": [
+          {
+            "file": "...",
+            "arch": [
+              {
+                "baseurl": "..."
+              }
+            ]
+          }
+        ]
+      }
+    }
+    """
+    with open(os.path.join(repo_folder, "Schutzfile"), "r", encoding="utf-8") as file:
+        schutzfile_data = json.load(file)
+    print(f"Updating schutzfile {os.path.join(repo_folder, 'Schutzfile')}")
+    for distro in schutzfile_data.keys():
+        if "repos" not in schutzfile_data[distro].keys():
+            continue
+
+        for repos in schutzfile_data[distro]["repos"]:
+            for key, arch_repos in repos.items():
+                if key == "file":
+                    continue
+
+                # Always update all repositories belonging to a distro:arch together,
+                # this avoids mixing snapshots for the same distro:arch, for instance
+                # using baseos from March and appstream from April.
+                snapshot_in_arch_missing = False
+                for repo in arch_repos:
+                    baseurl = repo["baseurl"]
+                    if not is_snapshot(baseurl) or is_singleton(baseurl, singletons):
+                        continue
+                    new_baseurl = re.sub("[0-9]{8}", suffix, baseurl)
+                    if basename(new_baseurl) not in live_snapshots:
+                        print(
+                            f"WARN: {repo['baseurl']} not updated due to expected snapshot being "
+                            "missing, did the snapshot job fail?"
+                        )
+                        snapshot_in_arch_missing = True
+                if snapshot_in_arch_missing:
+                    print(
+                        f"WARN: distro {key} arch {arch_repos} not updated as one of the snapshots "
+                        "is missing"
+                    )
+                    continue
+
+                for repo in arch_repos:
+                    baseurl = repo["baseurl"]
+                    if not is_snapshot(baseurl) or is_singleton(baseurl, singletons):
+                        continue
+                    repo["baseurl"] = re.sub("[0-9]{8}", suffix, baseurl)
+
+    if not dry_run:
+        with open(os.path.join(repo_folder, "Schutzfile"), "w", encoding="utf-8") as file:
+            json.dump(schutzfile_data, file, indent=2)
+    else:
+        print(json.dumps(schutzfile_data, indent=2))
+
+
+def write_test_repositories(repo_folder, dry_run, suffix, singletons, live_snapshots):
+    """
+    Update test repositories, which have the following structure:
+    distro.json:
+    {
+      "arch": [
+        {
+          "baseurl": "..."
+        }
+      ]
+    }
+    """
+    test_data_repositories_dir = os.path.join(repo_folder, "test/data/repositories/")
+    print(f"Updating {test_data_repositories_dir}")
+    if os.path.exists(test_data_repositories_dir):
+        repo_json_files = os.listdir(test_data_repositories_dir)
+        for repo_file in repo_json_files:
+            with open(
+                    os.path.join(test_data_repositories_dir, repo_file), "r", encoding="utf-8"
+            ) as file:
+                data = json.load(file)
+
+            for arch in data.keys():
+                # Always update all repositories belonging to a distro:arch together,
+                # this avoids mixing snapshots for the same distro:arch, for instance
+                # using baseos from March and appstream from April.
+                snapshot_in_arch_missing = False
+                for repo in data[arch]:
+                    baseurl = repo["baseurl"]
+                    if not is_snapshot(baseurl) or is_singleton(baseurl, singletons):
+                        continue
+                    new_baseurl = re.sub("[0-9]{8}", suffix, baseurl)
+                    if basename(new_baseurl) not in live_snapshots:
+                        print(
+                            f"WARN: {repo['baseurl']} not updated due to expected snapshot being "
+                            "missing, did the snapshot job fail?"
+                        )
+                        snapshot_in_arch_missing = True
+                if snapshot_in_arch_missing:
+                    print(
+                        f"WARN: distro {repo_file} arch {arch} not updated as one of the snapshots "
+                        "is missing"
+                    )
+                    continue
+
+                for repo in data[arch]:
+                    baseurl = repo["baseurl"]
+                    if not is_snapshot(baseurl) or is_singleton(baseurl, singletons):
+                        continue
+                    repo["baseurl"] = re.sub("[0-9]{8}", suffix, baseurl)
+
+            if not dry_run:
+                with open(
+                    os.path.join(test_data_repositories_dir, repo_file), "w", encoding="utf-8"
+                ) as file:
+                    json.dump(data, file, indent=2)
+            else:
+                print(json.dumps(data, indent=2))
 
 
 def main(suffix, repo_folder, dry_run):
@@ -16,77 +158,23 @@ def main(suffix, repo_folder, dry_run):
     """
     repo_files = os.listdir("repo/")
     singletons = []
-    snapshots = []
+    live_snapshots = []
+
     # Get a list of all repositories that contain 'singleton'
     for repo_file in repo_files:
-        with open(os.path.join("repo", repo_file), "r") as file:
+        with open(os.path.join("repo", repo_file), "r", encoding="utf-8") as file:
             data = json.load(file)
-        snapshots.append(data["snapshot-id"])
         if "singleton" in data.keys():
             singletons.append(data["snapshot-id"])
 
-    with open(os.path.join(repo_folder, "Schutzfile"), "r") as file:
-        data = json.load(file)
-
-    # Replace snapshot SUFFIX in repositories that don't have 'singleton' present
-    for key in data.keys():
-        if "repos" in data[key].keys():
-            for repo in data[key]["repos"]:
-                for arch_repos in repo:
-                    for i, _ in enumerate(repo[arch_repos]):
-                        if arch_repos == "file" or any(
-                            singleton in repo[arch_repos][i]["baseurl"]
-                            for singleton in singletons
-                        ):
-                            continue
-                        # Terribly inefficient way to check to see if the url has been removed
-                        if not any(snapshot in repo[arch_repos][i]["baseurl"]
-                                   for snapshot in snapshots):
-                            print(f"WARN: {repo[arch_repos][i]['baseurl']} has no current snapshot. Skipping it.")
-                            continue
-                        repo[arch_repos][i]["baseurl"] = re.sub(
-                            "[0-9]{8}",
-                            suffix,
-                            repo[arch_repos][i]["baseurl"],
-                        )
-
-    if not dry_run:
-        with open(os.path.join(repo_folder, "Schutzfile"), "w") as file:
-            json.dump(data, file, indent=2)
-    else:
-        print(json.dumps(data, indent=2))
-
-    # update repository snapshots in test/data/repositories/
-    # currently exists only for osbuild-composer
-    test_data_repositories_dir = os.path.join(repo_folder, "test/data/repositories/")
-    if os.path.exists(test_data_repositories_dir):
-        repo_json_files = os.listdir(test_data_repositories_dir)
-        for repo_file in repo_json_files:
-            with open(os.path.join(test_data_repositories_dir, repo_file), "r") as file:
-                data = json.load(file)
-
-            for arch in data.keys():
-                for repo in data[arch]:
-                    baseurl = repo["baseurl"]
-
-                    if any(singleton in baseurl for singleton in singletons):
-                        continue
-                    # Terribly inefficient way to check to see if the url has been removed
-                    if not any(snapshot in baseurl for snapshot in snapshots):
-                        print(f"WARN: {baseurl} has no current snapshot. Skipping it.")
-                        continue
-
-                    repo["baseurl"] = re.sub(
-                        "[0-9]{8}",
-                        suffix,
-                        baseurl,
-                    )
-
-            if not dry_run:
-                with open(os.path.join(test_data_repositories_dir, repo_file), "w") as file:
-                    json.dump(data, file, indent=2)
-            else:
-                print(json.dumps(data, indent=2))
+    # Get a list of the current snapshot in rpmrepo to validate any
+    # proposed update against
+    enumerate_response = requests.get("https://rpmrepo.osbuild.org/v2/enumerate", timeout=120)
+    if enumerate_response.status_code != 200:
+        raise RuntimeError("Unable to get live snapshots current enumerate cache")
+    live_snapshots = json.loads(enumerate_response.text)
+    write_schutzfile(repo_folder, dry_run, suffix, singletons, live_snapshots)
+    write_test_repositories(repo_folder, dry_run, suffix, singletons, live_snapshots)
 
 
 if __name__ == "__main__":
@@ -108,6 +196,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Print the new Schutzfile instead of overwriting the old one.")
+        help="Print the new Schutzfile instead of overwriting the old one.",
+    )
     args = parser.parse_args()
     main(args.suffix, args.repo, args.dry_run)

--- a/.github/workflows/ci-lint.yml
+++ b/.github/workflows/ci-lint.yml
@@ -30,4 +30,5 @@ jobs:
           --disable duplicate-code \
           src/ctl \
           src/gateway/*.py \
-          src/script/*.py
+          src/script/*.py \
+          .github/scripts/*.py

--- a/.github/workflows/ci-repo.yml
+++ b/.github/workflows/ci-repo.yml
@@ -1,11 +1,11 @@
 #
-# CI Repo Configuration
+# CI Repo Configuration & github scripts
 #
 # This verifies the formatting of the repository configurations in ./repo/ and
 # tries to verify external references.
 #
 
-name: "CI Repo Configuration"
+name: "CI Repo Configuration & github scripts"
 
 on:
   pull_request:
@@ -13,9 +13,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  #
-  # Run repo-check.py
-  #
   repo-check:
     name: "Repo Configuration Check"
     runs-on: ubuntu-latest
@@ -28,3 +25,8 @@ jobs:
       run: |
         ./src/script/repo-check.py ./repo/*.json
         ./src/script/repo-check.py --check-external public ./repo/*.json
+
+  github-scripts-check:
+    - name: "Run update schutzfile tests"
+      run: |
+        python3 -m pytest ./.github/scripts/test_update_schutzfile.py


### PR DESCRIPTION
Do not assume that snapshot jobs always succeed. Validate any proposed
update to snapshot against the snapshots that actually exist. This
avoids proposing missing snapshots.
 
Group repository updates by distro:arch, so that snapshots from
different dates aren't mixed.

---

I renamed the repo configuration check so it also reflects the fact that it's testing github scripts. It succeeded on previous runs.
