### PR TITLE
RHEL-7: stop snapshotting RHUI client repo

### DIFF
--- a/repo-definitions.yaml
+++ b/repo-definitions.yaml
@@ -35,11 +35,6 @@ rhel:
 - release: '7.9'
   arch:
     - x86_64
-  base_url: https://download.devel.redhat.com/rhel-7/rel-eng/RHUI/latest-RHUI-Client-4-RHEL-7/compose/RHUI/x86_64/os/
-  snapshot_id_suffix: rhui-4
-- release: '7.9'
-  arch:
-    - x86_64
   base_url: http://download.devel.redhat.com/released/jboss/eap7/latest-released/JBEAP-7-RHEL-7/Server/x86_64/os/
   snapshot_id_suffix: jbeap7
 - release: '7.9'

--- a/repo/el7-x86_64-rhui-4.json
+++ b/repo/el7-x86_64-rhui-4.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "https://download.devel.redhat.com/rhel-7/rel-eng/RHUI/latest-RHUI-Client-4-RHEL-7/compose/RHUI/x86_64/os/",
-        "platform-id": "el7",
-        "snapshot-id": "el7-x86_64-rhui-4",
-        "storage": "rhvpn"
-}


### PR DESCRIPTION
Snapshotting the repo has been failing, because there are no more any new builds of RHUI client RPMs for RHEL-7.