### PR TITLE
Snapshot RHEL-10 RHUI-4 repos

### DIFF
--- a/repo-definitions.yaml
+++ b/repo-definitions.yaml
@@ -225,6 +225,16 @@ rhel:
 - release: '10.0'
   arch:
     - x86_64
+  base_url: http://download.devel.redhat.com/rhel-10/rel-eng/RHUI/latest-RHUI-Client-4-RHEL-10/compose/RHUI/x86_64/os/
+  snapshot_id_suffix: rhui-4
+- release: '10.0'
+  arch:
+    - aarch64
+  base_url: http://download.devel.redhat.com/rhel-10/rel-eng/RHUI/latest-RHUI-Client-4-RHEL-10/compose/RHUI/aarch64/os/
+  snapshot_id_suffix: rhui-4
+- release: '10.0'
+  arch:
+    - x86_64
   base_url: http://download.devel.redhat.com/devel/stratosphere-rhui-sync/rhui-microsoft-azure-rhel10/
   snapshot_id_suffix: rhui-azure
 


### PR DESCRIPTION
These are now available, so we can snapshot them and use for testing, instead of RHEL-9 rpms.

I noticed that we are still using el9 snapshots in el10 test repos in composer, while updating those that are already GA.