### PR TITLE
src/pull: use dnf4 to sync repositories

### DIFF
--- a/src/ctl/pull.py
+++ b/src/ctl/pull.py
@@ -71,8 +71,10 @@ class Pull(contextlib.AbstractContextManager):
         self._exitstack = None
 
     def _run_reposync(self):
+        subprocess.run(["dnf", "install", "-y", "dnf4"], stdout=subprocess.PIPE, check=True)
+
         cmd = [
-            "dnf", "reposync",
+            "dnf4", "reposync",
             "--config", self._path_dnfconf,
             "--download-metadata",
             "--download-path", self._path_repo,


### PR DESCRIPTION
dnf5 reposync times out on very large repositories like fedora
    updates. It is simply too slow, causing the snapshot workflow to time
    out after 6 hours.
