### PR TITLE
Don't snaposhot Google cloud SDK repositories

### DIFF
--- a/repo-definitions.yaml
+++ b/repo-definitions.yaml
@@ -106,12 +106,6 @@ rhel:
 - release: '8.0'
   arch:
     - x86_64
-  base_url: https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64/
-  snapshot_id_suffix: google-cloud-sdk
-  storage: public
-- release: '8.0'
-  arch:
-    - x86_64
   base_url: http://nginx.org/packages/rhel/8/x86_64/
   snapshot_id_suffix: nginx
   storage: public
@@ -204,12 +198,6 @@ rhel:
     - x86_64
   base_url: https://packages.cloud.google.com/yum/repos/google-compute-engine-el9-x86_64-stable/
   snapshot_id_suffix: google-compute-engine
-  storage: public
-- release: '9.0'
-  arch:
-    - x86_64
-  base_url: https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64/
-  snapshot_id_suffix: google-cloud-sdk
   storage: public
 
 # Snapshots of RHEL-9.0 eus repos
@@ -307,12 +295,6 @@ rhel:
     - x86_64
   base_url: https://packages.cloud.google.com/yum/repos/google-compute-engine-el10-x86-64-stable/
   snapshot_id_suffix: google-compute-engine
-  storage: public
-- release: '10.0'
-  arch:
-    - x86_64
-  base_url: https://packages.cloud.google.com/yum/repos/cloud-sdk-el10-x86_64/
-  snapshot_id_suffix: google-cloud-sdk
   storage: public
 
 # Snapshots of RHEL-10.1 nightly repos

--- a/repo/el10-x86_64-google-cloud-sdk.json
+++ b/repo/el10-x86_64-google-cloud-sdk.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "https://packages.cloud.google.com/yum/repos/cloud-sdk-el10-x86_64/",
-        "platform-id": "el10",
-        "snapshot-id": "el10-x86_64-google-cloud-sdk",
-        "storage": "public"
-}

--- a/repo/el8-x86_64-google-cloud-sdk.json
+++ b/repo/el8-x86_64-google-cloud-sdk.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "https://packages.cloud.google.com/yum/repos/cloud-sdk-el8-x86_64/",
-        "platform-id": "el8",
-        "snapshot-id": "el8-x86_64-google-cloud-sdk",
-        "storage": "public"
-}

--- a/repo/el9-x86_64-google-cloud-sdk.json
+++ b/repo/el9-x86_64-google-cloud-sdk.json
@@ -1,6 +1,0 @@
-{
-        "base-url": "https://packages.cloud.google.com/yum/repos/cloud-sdk-el9-x86_64/",
-        "platform-id": "el9",
-        "snapshot-id": "el9-x86_64-google-cloud-sdk",
-        "storage": "public"
-}


### PR DESCRIPTION
We do not install any packages by default from these repos for our base image definitions, so we do not need to snapshot them for CI purposes.