### PR TITLE
fedora: move 44 to GA

### DIFF
--- a/repo-definitions.yaml
+++ b/repo-definitions.yaml
@@ -312,15 +312,6 @@ rhel:
 
 fedora:
 # stable releases
-- release: '42'
-  stream: releases
-  singleton: '20250512'
-  repo_name:
-    - Everything
-- release: '42'
-  stream: updates
-  repo_name:
-    - Everything
 - release: '43'
   stream: releases
   singleton: '20260106'
@@ -330,10 +321,17 @@ fedora:
   stream: updates
   repo_name:
     - Everything
+- release: '44'
+  stream: releases
+  singleton: '20260430'
+  repo_name:
+    - Everything
+- release: '44'
+  stream: updates
+  repo_name:
+    - Everything
 
 # branched, in -development release
-- release: '44'
-  stream: development
 
 # rawhide
 - release: '45'

--- a/repo/f44-aarch64-fedora.json
+++ b/repo/f44-aarch64-fedora.json
@@ -1,0 +1,7 @@
+{
+        "base-url": "https://dl01.fedoraproject.org/pub/fedora/linux/releases/44/Everything/aarch64/os/",
+        "platform-id": "f44",
+        "singleton": "20260430",
+        "snapshot-id": "f44-aarch64-fedora",
+        "storage": "public"
+}

--- a/repo/f44-aarch64-updates-released.json
+++ b/repo/f44-aarch64-updates-released.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://dl01.fedoraproject.org/pub/fedora/linux/updates/44/Everything/aarch64/",
+        "platform-id": "f44",
+        "snapshot-id": "f44-aarch64-updates-released",
+        "storage": "public"
+}

--- a/repo/f44-ppc64le-fedora.json
+++ b/repo/f44-ppc64le-fedora.json
@@ -1,0 +1,7 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/releases/44/Everything/ppc64le/os/",
+        "platform-id": "f44",
+        "singleton": "20260430",
+        "snapshot-id": "f44-ppc64le-fedora",
+        "storage": "public"
+}

--- a/repo/f44-ppc64le-updates-released.json
+++ b/repo/f44-ppc64le-updates-released.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/updates/44/Everything/ppc64le/",
+        "platform-id": "f44",
+        "snapshot-id": "f44-ppc64le-updates-released",
+        "storage": "public"
+}

--- a/repo/f44-s390x-fedora.json
+++ b/repo/f44-s390x-fedora.json
@@ -1,0 +1,7 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/releases/44/Everything/s390x/os/",
+        "platform-id": "f44",
+        "singleton": "20260430",
+        "snapshot-id": "f44-s390x-fedora",
+        "storage": "public"
+}

--- a/repo/f44-s390x-updates-released.json
+++ b/repo/f44-s390x-updates-released.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://dl.fedoraproject.org/pub/fedora-secondary/updates/44/Everything/s390x/",
+        "platform-id": "f44",
+        "snapshot-id": "f44-s390x-updates-released",
+        "storage": "public"
+}

--- a/repo/f44-x86_64-fedora.json
+++ b/repo/f44-x86_64-fedora.json
@@ -1,0 +1,7 @@
+{
+        "base-url": "https://dl01.fedoraproject.org/pub/fedora/linux/releases/44/Everything/x86_64/os/",
+        "platform-id": "f44",
+        "singleton": "20260430",
+        "snapshot-id": "f44-x86_64-fedora",
+        "storage": "public"
+}

--- a/repo/f44-x86_64-updates-released.json
+++ b/repo/f44-x86_64-updates-released.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://dl01.fedoraproject.org/pub/fedora/linux/updates/44/Everything/x86_64/",
+        "platform-id": "f44",
+        "snapshot-id": "f44-x86_64-updates-released",
+        "storage": "public"
+}


### PR DESCRIPTION
Fedora 44 is GA; we need to include the updates repositories.