### PR TITLE
repo: add e10.0 CRB repos

### DIFF
--- a/repo-definitions.yaml
+++ b/repo-definitions.yaml
@@ -334,6 +334,7 @@ rhel:
   repo_name:
     - baseos
     - appstream
+    - codeready-builder
 - release: '10.0'
   eus: true
   arch:

--- a/repo/el10-aarch64-codeready-builder-e10.0.json
+++ b/repo/el10-aarch64-codeready-builder-e10.0.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://rhsm-pulp.corp.redhat.com/content/eus/rhel10/10.0/aarch64/codeready-builder/os/",
+        "platform-id": "el10",
+        "snapshot-id": "el10-aarch64-codeready-builder-e10.0",
+        "storage": "rhvpn"
+}

--- a/repo/el10-ppc64le-codeready-builder-e10.0.json
+++ b/repo/el10-ppc64le-codeready-builder-e10.0.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://rhsm-pulp.corp.redhat.com/content/eus/rhel10/10.0/ppc64le/codeready-builder/os/",
+        "platform-id": "el10",
+        "snapshot-id": "el10-ppc64le-codeready-builder-e10.0",
+        "storage": "rhvpn"
+}

--- a/repo/el10-s390x-codeready-builder-e10.0.json
+++ b/repo/el10-s390x-codeready-builder-e10.0.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://rhsm-pulp.corp.redhat.com/content/eus/rhel10/10.0/s390x/codeready-builder/os/",
+        "platform-id": "el10",
+        "snapshot-id": "el10-s390x-codeready-builder-e10.0",
+        "storage": "rhvpn"
+}

--- a/repo/el10-x86_64-codeready-builder-e10.0.json
+++ b/repo/el10-x86_64-codeready-builder-e10.0.json
@@ -1,0 +1,6 @@
+{
+        "base-url": "https://rhsm-pulp.corp.redhat.com/content/eus/rhel10/10.0/x86_64/codeready-builder/os/",
+        "platform-id": "el10",
+        "snapshot-id": "el10-x86_64-codeready-builder-e10.0",
+        "storage": "rhvpn"
+}


### PR DESCRIPTION
As the mock configs didn't exist yet for 10.0, valid mock templates are generated based on repositories in the Schutzfile. In order to build the osbuild-composer rpm, CRB is needed.