### PR TITLE
snapshot: compare repomds before distrosync

### DIFF
--- a/src/ctl/snapshot.py
+++ b/src/ctl/snapshot.py
@@ -6,9 +6,12 @@ indexes it, and pushes it to remote storage.
 
 # pylint: disable=duplicate-code,invalid-name,too-few-public-methods
 
+import concurrent.futures
 import datetime
+import hashlib
 import json
 import os
+import urllib.request
 
 import boto3
 import botocore.exceptions
@@ -47,6 +50,90 @@ class Snapshot:
                 return False
             raise
 
+    @staticmethod
+    def _fetch_repomd_checksum(base_url):
+        """Fetch upstream repomd.xml and return its checksum.
+
+        Returns None if the fetch fails, causing the caller to fall
+        through to the full pipeline.
+        """
+        repomd_url = base_url.rstrip("/") + "/repodata/repomd.xml"
+        try:
+            with urllib.request.urlopen(repomd_url, timeout=30) as resp:
+                data = resp.read()
+            return "sha256-" + hashlib.sha256(data).hexdigest()
+        except (OSError, ValueError) as err:
+            print(f"Warning: failed to fetch repomd.xml from {repomd_url}: {err}")
+            return None
+
+    @staticmethod
+    def _get_previous_repomd_checksum(snapshot_id, suffix):
+        """Get the repomd.xml checksum from an existing snapshot's refs."""
+        s3c = boto3.client("s3")
+        key = f"data/ref/{snapshot_id}{suffix}/repodata/repomd.xml"
+        try:
+            resp = s3c.head_object(Bucket="rpmrepo-storage", Key=key)
+            return resp["Metadata"].get("rpmrepo-checksum")
+        except botocore.exceptions.ClientError:
+            return None
+
+    @staticmethod
+    def _get_latest_suffix(snapshot_id):
+        """Find the most recent snapshot suffix from S3 thread markers."""
+        s3c = boto3.client("s3")
+        prefix = f"data/thread/{snapshot_id}/{snapshot_id}-"
+
+        suffixes = []
+        paginator = s3c.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket="rpmrepo-storage", Prefix=prefix):
+            for obj in page.get("Contents", []):
+                name = obj["Key"].rsplit("/", 1)[-1]
+                suffixes.append(name[len(snapshot_id):])
+
+        if not suffixes:
+            return None
+        suffixes.sort()
+        return suffixes[-1]
+
+    @staticmethod
+    def _clone_snapshot(snapshot_id, old_suffix, new_suffix):
+        """Clone snapshot references from a previous suffix to a new one.
+
+        Copies all ref objects and creates a new thread marker. Data objects
+        are content-addressed and shared across snapshots, so they don't
+        need copying.
+        """
+        s3c = boto3.client("s3")
+
+        old_prefix = f"data/ref/{snapshot_id}{old_suffix}/"
+        new_prefix = f"data/ref/{snapshot_id}{new_suffix}/"
+
+        objects = []
+        paginator = s3c.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket="rpmrepo-storage", Prefix=old_prefix):
+            objects.extend(page.get("Contents", []))
+
+        def copy_one(obj):
+            old_key = obj["Key"]
+            new_key = new_prefix + old_key[len(old_prefix):]
+            s3c.copy_object(
+                Bucket="rpmrepo-storage",
+                CopySource={"Bucket": "rpmrepo-storage", "Key": old_key},
+                Key=new_key,
+                MetadataDirective="COPY",
+            )
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=32) as executor:
+            list(executor.map(copy_one, objects))
+
+        s3c.put_object(
+            Body=b"",
+            Bucket="rpmrepo-storage",
+            Key=f"data/thread/{snapshot_id}/{snapshot_id}{new_suffix}",
+        )
+
+        return len(objects)
+
     def run_one(self, path):
         """Run snapshot for a single repo config file"""
 
@@ -61,6 +148,22 @@ class Snapshot:
         if self._snapshot_exists(snapshot_id, suffix):
             print(f"Snapshot {snapshot_id}{suffix} exists already, skipping")
             return
+
+        # Check if the upstream repo has changed since the last snapshot.
+        # If not, clone the previous snapshot's refs instead of re-pulling.
+        upstream_checksum = self._fetch_repomd_checksum(base_url)
+        if upstream_checksum is not None:
+            prev_suffix = self._get_latest_suffix(snapshot_id)
+            if prev_suffix is not None:
+                prev_checksum = self._get_previous_repomd_checksum(
+                    snapshot_id, prev_suffix,
+                )
+                if upstream_checksum == prev_checksum:
+                    print(f"Upstream unchanged for {snapshot_id}, "
+                          f"cloning {snapshot_id}{prev_suffix}...")
+                    n = self._clone_snapshot(snapshot_id, prev_suffix, suffix)
+                    print(f"Snapshot {snapshot_id}{suffix} cloned ({n} refs).")
+                    return
 
         # Derive a stable cache identifier from the snapshot-id so the
         # dnf cache is reused across runs of the same repo config.


### PR DESCRIPTION
Instead of always distrosyncing repositories compare the sha256 checksum of the "upstream" repository with the checksum we got for our latest snapshot. If a repository is unchanged this should severely diminish the time spent.

Let's see how often this actually happens. It probably won't affect *much*.

As a follow-up we could only download *changed* packages between the two repomds.